### PR TITLE
Feat(DK-283): 회원가입 프로필 이미지 업로드 구현

### DIFF
--- a/src/pages/Register/components/profileUpload/profileUpload.tsx
+++ b/src/pages/Register/components/profileUpload/profileUpload.tsx
@@ -3,6 +3,7 @@ import styles from "./_profile_upload.module.scss";
 import { InfoFilled } from "@/svg/infoFilled.tsx";
 import { gray40, gray60 } from "@/styles/abstracts/colors.ts";
 import Button from "@/components/atom/button/button.tsx";
+import { ProfileImageState } from "../../composite/profileSet/profileSet";
 
 export default function ProfileUpload({
   email,
@@ -11,12 +12,15 @@ export default function ProfileUpload({
   defaultImagePath,
 }: {
   email: string;
-  profileImage: string;
-  setProfileImage: React.Dispatch<React.SetStateAction<string>>;
+  profileImage: ProfileImageState;
+  setProfileImage: React.Dispatch<React.SetStateAction<ProfileImageState>>;
   defaultImagePath: string;
 }) {
   const onDeleteProfileImage = () => {
-    setProfileImage(defaultImagePath);
+    setProfileImage({
+      url: defaultImagePath,
+      file: null,
+    });
   };
 
   const onFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -24,7 +28,10 @@ export default function ProfileUpload({
     if (file) {
       const reader = new FileReader();
       reader.onload = () => {
-        setProfileImage(reader.result as string);
+        setProfileImage({
+          url: reader.result as string,
+          file: file,
+        });
       };
       reader.readAsDataURL(file);
     }
@@ -35,7 +42,7 @@ export default function ProfileUpload({
       <div className={styles["profile-email-container"]}>
         <div className={styles["custom-file-upload"]}>
           <img
-            src={profileImage}
+            src={profileImage.url}
             alt="프로필 이미지"
             className={styles["profile-image"]}
           />

--- a/src/pages/Register/composite/profileSet/profileSet.tsx
+++ b/src/pages/Register/composite/profileSet/profileSet.tsx
@@ -15,6 +15,12 @@ import {
   sendTermsAgreement,
   updateUser,
 } from "@/services/server/authService";
+import { uploadImage } from "@/services/server/imageService";
+
+export interface ProfileImageState {
+  url: string;
+  file: File | null;
+}
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export default function ProfileSet() {
@@ -23,7 +29,10 @@ export default function ProfileSet() {
   const nextPage = "/register/complete";
 
   const defaultImagePath = "/public/assets/image/default-profile.png";
-  const [profileImage, setProfileImage] = useState<string>(defaultImagePath);
+  const [profileImage, setProfileImage] = useState<ProfileImageState>({
+    url: defaultImagePath,
+    file: null,
+  });
   const [user, setUser] = useAtom<RegisterInfoType>(RegisterInfoAtom);
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
 
@@ -39,31 +48,49 @@ export default function ProfileSet() {
     setUser({
       ...user,
       nickname,
-      profileImage,
+      profileImage: profileImage.file,
     });
     setIsSubmitted(true);
   };
 
   const handleSignUp = async () => {
     const { id, termsAgreements, ...userInfo } = user;
+    // TODO: 프로필 이미지 없을 경우?
 
-    if (method === "email") {
-      // 이메일
-      const emailUserInfo = userInfo;
+    if (userInfo.profileImage) {
+      // 프로필 이미지 업로드
+      const imageUrl = await uploadImage({
+        image: userInfo.profileImage,
+        imageTarget: "MEMBER_PROFILE",
+      });
 
-      // 1. 회원가입
-      // 2. 약관 동의
-      await Promise.all([
-        emailSignup(emailUserInfo),
-        sendTermsAgreement(termsAgreements),
-      ]);
-    } else {
-      // 소셜
-      const { password, ...socialUserInfo } = userInfo;
-      // 1. 프로필 업데이트
-      await updateUser(socialUserInfo);
+      // }
+
+      if (method === "email") {
+        // 이메일 회원가입
+        const emailUserInfo = {
+          ...userInfo,
+          profileImage: imageUrl,
+        };
+
+        // 1. 회원가입
+        // 2. 약관 동의
+        await Promise.all([
+          emailSignup(emailUserInfo),
+          sendTermsAgreement(termsAgreements),
+        ]);
+      } else {
+        // 소셜 회원가입
+        const { password, ...rest } = userInfo;
+        const socialUserInfo = {
+          ...rest,
+          profileImage: imageUrl,
+        };
+        // 프로필 업데이트
+        await updateUser(socialUserInfo);
+      }
+      navigate(nextPage);
     }
-    navigate(nextPage);
   };
 
   useEffect(() => {

--- a/src/services/server/authService.ts
+++ b/src/services/server/authService.ts
@@ -102,7 +102,7 @@ export const emailSignup = async (userInfo: {
 export const updateUser = async (userInfo: {
   nickname: string;
   email: string;
-  profileImage: string;
+  profileImage: string; // TODO: 필수인가?
 }) => {
   try {
     const response = await axios.put("/members/login-user", userInfo);

--- a/src/services/server/imageService.ts
+++ b/src/services/server/imageService.ts
@@ -1,0 +1,21 @@
+import axios from "axios";
+
+// 이미지 업로드
+export const uploadImage = async ({
+  image,
+  imageTarget,
+}: {
+  image: File;
+  imageTarget: "MEMBER_PROFILE" | "STUDY_GROUP_PROFILE";
+}): Promise<string> => {
+  const formData = new FormData();
+  formData.append("file", image);
+
+  try {
+    const { data } = await axios.post(`/images/${imageTarget}`, formData);
+    console.log(data);
+    return data.url;
+  } catch (error) {
+    throw new Error(`파일(이미지) 업로드 실패: ${error}`);
+  }
+};

--- a/src/store/userAtom.ts
+++ b/src/store/userAtom.ts
@@ -7,6 +7,6 @@ export const RegisterInfoAtom = atom<RegisterInfoType>({
   email: "",
   password: "",
   nickname: "",
-  profileImage: "",
-  // roles: [],
+  profileImage: null,
+  termsAgreements: [],
 });

--- a/src/types/UserType.ts
+++ b/src/types/UserType.ts
@@ -2,7 +2,7 @@ export interface UserBaseType {
   id: number;
   email: string;
   nickname: string;
-  profileImage: string;
+  profileImage: File | null;
 }
 
 // (아마도) 전체에서만 사용될 유저 타입
@@ -13,7 +13,6 @@ export interface UserType extends UserBaseType {
 
 // 회원가입에서만 사용되는 타입
 export interface RegisterInfoType extends UserBaseType {
-  id: number;
   password: string;
   termsAgreements: number[]; // 이메일 회원가입인 경우만 사용
 }


### PR DESCRIPTION
- 회원가입 프로필 업데이트: 이미지 업로드 기능 구현
- `imageService.ts`에 이미지 업로드를 위한 uploadImage 함수 작성
- 회원가입 사용자 정보 atom의 profileImage 타입을 **string**(url)에서 **File** 타입으로 변경하여 이미지 업로드 지원 
(이에 따라 UserBaseType의 profileImage 필드 타입도 함께 변경됨)