### PR TITLE
Dk 165:  토큰 리프레시 로직 변경 대응

### DIFF
--- a/src/services/server/authService.ts
+++ b/src/services/server/authService.ts
@@ -126,9 +126,11 @@ export const getUser = async (): Promise<UserType> => {
         console.log("in 404 in get user");
         throw error;
       }
-      if (axiosError.response?.status === 500) { 
-        console.log("500 in get user");
-        fetchRefreshToken();// TODO: 백엔드에서 401 정의 후 fetchRefreshToken 호출위치 그곳으로 변경
+      if (axiosError.response?.status === 403) { 
+        //TODO: 403에러는 리프레시 토큰이 유효하지 않아 재로그인 필요한 상황이다. 리팩토링하여 모든 요청에 적용 필요
+        console.log("get user 403");
+        localApi.removeCertification();
+        throw error;
       }
       throw new Error(`로그인 요청: ${error}`);
     } else {
@@ -212,24 +214,5 @@ export const matchEmailCode = async ({
     // 인증코드가 일치하지 않을 경우
     // TODO: 상세한 에러 처리 필요
     throw new Error(`인증코드 일치 실패: ${error}`);
-  }
-};
-
-export const fetchRefreshToken = async () => {
-  try {
-    const { data } = await axios.post("/token/refresh");
-    return data;
-  } catch (error: unknown) {
-    if (axios.isAxiosError(error)) {
-      const axiosError = error as AxiosError;
-      if (axiosError.response?.status === 404) {
-        console.log("refresh token 404");
-        localApi.removeCertification();
-        throw error;
-      }
-      throw new Error(`리프레시 토큰 요청: ${error}`);
-    } else {
-      throw new Error(`Unexpected error: ${error}`);
-    }
   }
 };


### PR DESCRIPTION
### 1. 리프레시 요청 api 로직 삭제
- access token 만료 후 백엔드에서 자동으로 refresh 하는 것으로 로직이 변경되어, 프론트 측에서 리프레시 요청을 하는 로직을 제거했습니다.

### 2. 로그인 요청 구현
- api 요청 후 403 응답이 오면 '리프레시 토큰 유효하지 않음'의 의미이기 때문에 사용자가 다시 로그인 하도록 구현하였습니다.