### PR TITLE
Feat(DK-349): 이메일 인증코드 재전송 구현

### DIFF
--- a/src/components/composite/loginModal/loginModal.tsx
+++ b/src/components/composite/loginModal/loginModal.tsx
@@ -18,6 +18,7 @@ import { Invisible } from "@/svg/invisible.tsx";
 import { useNavigate } from "react-router-dom";
 import { useAtom } from "jotai";
 import { IsEmailLoginPage } from "@/store/authModalAtom.ts";
+import { authService } from "@/services/server/authService.ts";
 interface LoginModalProps {
   closeModal: () => void;
 }
@@ -41,14 +42,19 @@ const LoginModal = ({ closeModal }: LoginModalProps) => {
   const [isPasswordVisible, setIsPasswordVisible] = useState<boolean>(false);
   const isInputFilled = email && password;
 
-  const [isMatched] = useState<boolean>(false);
+  const [isMatched, setIsMatched] = useState<boolean>(false);
 
   const handlePasswordVisible = () => {
     setIsPasswordVisible((prev) => !prev);
   };
 
+  // 로그인
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    console.log("로그인");
+    // 로그인 멤버 정보 -> 아이디
+    authService.emailLogin({ email, password });
+    
   };
 
   const handleSignupClick = () => {

--- a/src/components/composite/socialAuthButton/socialAuthButton.tsx
+++ b/src/components/composite/socialAuthButton/socialAuthButton.tsx
@@ -13,23 +13,15 @@ import { useAtom } from "jotai";
 const SocialAuthButton: React.FC<{
   socialType: SocialLoginType;
 }> = ({ socialType }) => {
-  // const { redirectToAuthPage, loading } = useRedirectToAuthPage();
   const [, setIsEmailLoginPage] = useAtom(IsEmailLoginPage);
-  // const emailRegisterPage = "/register/email";
 
   const handleAuth = async () => {
-    // const action =
-    //   authType === AuthType.SIGNUP ? AUTH_ACTION.SIGN_UP : AUTH_ACTION.LOGIN;
-    // localStorage.setItem(LOCAL_STORAGE_KEY.AUTH_ACTION, action);
-
     if (socialType === SocialLoginType.EMAIL) {
       // 이메일 회원가입
-      // window.location.href = emailRegisterPage;
       // 이메일로 계속하기 누르면 로그인 창 뜨고 사용자가 선택해서 회원가입할 수 있도록 하기
       setIsEmailLoginPage(true);
     } else {
-      // 소셜 미디어 회원가입
-      // await redirectToAuthPage(socialType);
+      // 소셜 회원가입
       const redirectUrl = "https://local.dev.dokbaro.kro.kr:5173/";
       window.location.href = `${
         import.meta.env.VITE_API_URL

--- a/src/pages/Register/composite/email/verification/_verification.module.scss
+++ b/src/pages/Register/composite/email/verification/_verification.module.scss
@@ -15,6 +15,15 @@
   .next {
     margin-top: 24px;
   }
+  .resend {
+    color: $primary;
+    margin: 0 auto;
+    margin-top: 16px;
+    &:disabled {
+      background: none;
+      border: none;
+    }
+  }
 
   .message-container {
     display: flex;

--- a/src/pages/Register/composite/email/verification/verification.tsx
+++ b/src/pages/Register/composite/email/verification/verification.tsx
@@ -30,6 +30,7 @@ export default function Verification({
 
   const [isMatch, setIsMatch] = useState<boolean | undefined>(undefined);
   const [isEmailSent, setIsEmailSent] = useState<boolean>(false);
+  const [isAlreadyRegisteredEmail, setIsAlreadyRegisteredEmail] = useState<boolean>(false);
 
   const handleNext = async () => {
     if (!email || !isEmailValid) {
@@ -42,6 +43,11 @@ export default function Verification({
     // 인증코드 발송
     await authService.sendEmailCode(email);
     setIsEmailSent(true);
+  };
+
+  // 이메일 인증코드 재전송
+  const handleResend = async () => {
+    await authService.resendEmailCode(email);
   };
 
   const handleCodeChange = (
@@ -174,6 +180,15 @@ export default function Verification({
         disabled={!isEmailSent ? !isEmailValid : fullCode.length !== 6}
       >
         {!isEmailSent ? <>다음</> : <>인증하기</>}
+      </Button>
+      <Button
+        color="transparent"
+        size="xsmall"
+        className={styles.resend}
+        onClick={handleResend}
+        disabled={!isEmailSent}
+      >
+        이메일 재전송하기
       </Button>
     </section>
   );

--- a/src/services/server/authService.ts
+++ b/src/services/server/authService.ts
@@ -107,9 +107,14 @@ class AuthService {
       console.log("이메일 회원가입 post 응답", response);
       return response;
     } catch (error) {
-      throw new Error(`이메일 회원가입 실패: ${error}`);
+      if (error instanceof Error) {
+        console.error("에러 메시지:", error.message);
+      } else {
+        console.error("알 수 없는 에러:", error);
+      }
     }
   };
+
   // 이메일 로그인
   emailLogin = async (loginInfo: { email: string; password: string }) => {
     try {
@@ -118,6 +123,7 @@ class AuthService {
       Object.entries(loginInfo).forEach(([key, value]) => {
         formData.append(key, value);
       });
+      console.log(loginInfo);
       const response = await axiosInstance.post("/auth/login/email", formData, {
         headers: {
           "Content-Type": "application/x-www-form-urlencoded",
@@ -127,6 +133,7 @@ class AuthService {
       return response;
     } catch (error) {
       throw new Error(`이메일 로그인 실패: ${error}`);
+      return false;
     }
   };
 
@@ -218,7 +225,32 @@ class AuthService {
         console.log(response);
       }
     } catch (error) {
-      throw new Error(`이메일로 인증코드 보내기 실패: ${error}`);
+      const err = error as AxiosError;
+      if (err.response) {
+        const data = err.response.data as { message: string };
+        // 400 -> 이미 가입된 이메일
+        // {
+        //   status: 400
+        // }
+        // console.log(data);
+        throw new Error(data.message);
+      }
+    }
+  };
+
+  resendEmailCode = async (email: string) => {
+    try {
+      const response = await axiosInstance.post(
+        "/email-authentications/recreate",
+        {
+          email: email,
+        }
+      );
+      if (response.status === 204) {
+        console.log(response);
+      }
+    } catch (error) {
+      throw new Error(`이메일 인증코드 재전송 실패: ${error}`);
     }
   };
 


### PR DESCRIPTION
- 이메일 인증 코드 재전송 기능을 구현했습니다.
- 이메일 인증 코드 전송 후 중복 이메일일 경우 처리를 위해 에러 처리 로직을 리팩토링해야 한다고 판단하여, 작업 중단하고 에러 처리 관련 작업을 DK-294(클라이언트 에러 처리)에서 진행하겠습니다.