### PR TITLE
Fix(DK-369): 퀴즈 생성 다음 버튼 동작 이상 문제 수정

### DIFF
--- a/src/pages/CreateQuiz/composite/quizSettingsForm/quizSettingsForm.tsx
+++ b/src/pages/CreateQuiz/composite/quizSettingsForm/quizSettingsForm.tsx
@@ -16,6 +16,11 @@ export default function QuizSettingsForm() {
     IsQuizNextButtonEnabledAtom
   );
 
+  // 다음 버튼 초기화
+  useEffect(() => {
+    setIsQuizNextButtonEnabled(false);
+  }, []);
+
   const [selectedOptions, setSelectedOptions] = useState<SelectedOptions>(
     () => ({
       "view-access": quizCreationInfo.viewScope,
@@ -52,7 +57,7 @@ export default function QuizSettingsForm() {
     );
 
     setIsQuizNextButtonEnabled(isAllSelected);
-  }, [selectedOptions, setIsQuizNextButtonEnabled]);
+  }, [Object.values(selectedOptions)]);
 
   return (
     <>
@@ -117,16 +122,6 @@ const getQuizSettings = (isStudyGroupSelected: boolean): QuizSettingType[] => [
           },
         ],
 
-    // [
-    //   {
-    //     label: "나만",
-    //     description: "나만 이 퀴즈를 편집할 수 있습니다.",
-    //   },
-    //   {
-    //     label: "스터디원만",
-    //     description: "스터디원이 이 퀴즈를 편집할 수 있습니다.",
-    //   },
-    // ],
     icon: "/assets/svg/quizSettingForm/edit.svg",
   },
 ];

--- a/src/pages/CreateQuiz/layout/quizCreationFormLayout/quizCreationFormLayout.tsx
+++ b/src/pages/CreateQuiz/layout/quizCreationFormLayout/quizCreationFormLayout.tsx
@@ -31,8 +31,9 @@ export default function QuizCreationFormLayout({
   setCurrentStep: React.Dispatch<React.SetStateAction<number>>;
 }) {
   const navigate = useNavigate();
-  const [isQuizNextButtonEnabled, setIsQuizNextButtonEnabled] =
-    useAtom<boolean>(IsQuizNextButtonEnabledAtom);
+  const [isQuizNextButtonEnabled] = useAtom<boolean>(
+    IsQuizNextButtonEnabledAtom
+  );
   const [quizCreationInfo] = useAtom<QuizCreationType>(QuizCreationInfoAtom);
   const [, setErrorModalTitle] = useAtom(errorModalTitleAtom);
   const [openModal] = useAtom(openErrorModalAtom);
@@ -148,11 +149,9 @@ export default function QuizCreationFormLayout({
     return;
   };
   const endStep = steps.length - 1;
-  // const { updateQuizCreationInfo } = useUpdateQuizCreationInfo();
 
   const goToNextStep = async () => {
     if (currentStep === 2.2) {
-      console.log("validation check!");
       //TODO: 질문이 하나도 없을 때 버튼 다시 disable 필요
 
       // - 정답 선택 안 했을 때: 답안이 선택되었는지 확인하세요.
@@ -198,9 +197,6 @@ export default function QuizCreationFormLayout({
         return;
       }
     }
-
-    // 새로운 단계(페이지) 넘어갈때 button 상태 다시 disabled로 변경.
-    setIsQuizNextButtonEnabled(false);
   };
 
   const step: Step = getCurrentStep();

--- a/src/store/quizAtom.ts
+++ b/src/store/quizAtom.ts
@@ -1,5 +1,4 @@
 import { QuizCreationType } from "@/types/QuizType";
-import { StudyGroupPreviewType } from "@/types/StudyGroupType";
 import { atom } from "jotai";
 
 // 퀴즈 생성 단계 다음 버튼의 enabled 여부를 저장


### PR DESCRIPTION
- 의존성 배열에서 객체 자체 대신 객체 값 배열을 사용하도록 수정하였습니다.
- '다음' 버튼 enable/diable 처리 위치를 각 페이지 컴포넌트 내부로 변경하였습니다. (각 페이지별 처리 상이, nav바를 통한 이동 등의 이유. 이후 추가 리팩토링에서 수정될 수 있음)