### PR TITLE
Fix(DK-424): 카테고리 ID에 따른 네비게이션 처리 수정

### DIFF
--- a/src/components/composite/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/composite/Breadcrumb/Breadcrumb.tsx
@@ -27,7 +27,7 @@ export default function Breadcrumb({ list, parentPage }: Props) {
   const handleClick = (id: string | undefined) => {
     // navigateWithParams(id, "BOOKS", ["category"], ["page"]);
     navigateWithParams({
-      category: id,
+      category: Number(id) > 2 ? id : undefined,
       parentPage: "books",
       excludeParams: ["page"],
     });


### PR DESCRIPTION
- 모든 카테고리가 ID 2의 하위 카테고리이므로, 카테고리 ID가 2 이하일 경우 undefined로 처리하도록 수정
- handleClick 로직을 수정하여 page 파라미터를 제외하고, parentPage를 "books"로 설정하여 이동하도록 변경