### PR TITLE
Fix(DK-361): 퀴즈 수정하기 - question id 가 set 안되는 문제 수정

### DIFF
--- a/src/hooks/useQuestionTemplate.ts
+++ b/src/hooks/useQuestionTemplate.ts
@@ -21,14 +21,13 @@ export const useQuestionTemplate = (
     questionFormType: AnswerType,
   ): (CheckBoxOption | RadioOptionType)[] => {
     const question: QuizQuestionType = getQuestion();
-    console.log("in template: %o:", question.selectOptions);
+
     const initialOptions =
       question?.selectOptions.map((option) => ({
         id: option.id,
         value: option.value,
         label: option.option,
       })) ?? [];
-    console.log("initi: %o", initialOptions);
 
     return questionFormType === "MULTIPLE_CHOICE_MULTIPLE_ANSWER"
       ? (initialOptions as CheckBoxOption[])

--- a/src/pages/CreateQuiz/layout/QuizCreationFormLayout/QuizCreationFormLayout.tsx
+++ b/src/pages/CreateQuiz/layout/QuizCreationFormLayout/QuizCreationFormLayout.tsx
@@ -25,6 +25,7 @@ import { useEffect } from "react";
 import ROUTES from "@/data/routes";
 import { invalidQuestionFormIdAtom } from "@/store/quizAtom";
 import React from "react";
+import { QuestionMarkOutlined } from "@mui/icons-material";
 
 export default function QuizCreationFormLayout({
   isEditMode,
@@ -98,8 +99,12 @@ export default function QuizCreationFormLayout({
     const uploadedImgQuestions = quizCreationInfo.questions!.map(
       async (question) => {
         const { id, ...rest } = question;
-        void id;
+
         return {
+          // 기존 퀴즈 id의 경우 선택옵션 순서대로 0,1,2... 이런식으로 생성됨
+          // 새로 추가된 퀴즈 id의 경우 timemillis 값이므로 무조건 1000 이상의 수 이다.
+          // 질문 수정의 경우 기존 id, 질문을 새로 create하는 경우 undefined값으로 set
+          id: (id) > 1000 ? (void id) : id,
           ...rest,
           answerExplanationImages: await requestUploadExplanationImages(
             question.answerExplanationImages,
@@ -152,10 +157,9 @@ export default function QuizCreationFormLayout({
       return;
     }
 
-    // 한글을 영어로 바꾸는 함수.
-    // 수정할 땐 영어가 들어온다
-    const viewScopeKey = isEditMode ? quizCreationInfo.viewScope : getScopeKeyByTranslation(quizCreationInfo.viewScope); 
-   
+    // 한글을 영어로 바꾸는 함수. 결과가 null이면 viewScope 값 그대로 사용
+    const viewScopeKey: ViewScope = getScopeKeyByTranslation(quizCreationInfo.viewScope) ?? quizCreationInfo.viewScope;
+
     if (
       quizCreationInfo.title === null ||
       quizCreationInfo.description === null ||

--- a/src/types/QuizType.ts
+++ b/src/types/QuizType.ts
@@ -148,6 +148,7 @@ export interface QuizRequestType {
 }
 
 export type QuizQuestionRequestApiType = {
+  id?:number; // 수정하기 api 요청 시 id가 없으면 create, 있으면 modify
   content: string;
   selectOptions: string[];
   answerExplanationContent: string;


### PR DESCRIPTION
### 퀴즈 수정시 기존 질문을 수정할 때 질문이 새로 생성되어버리는 문제를 개선했습니다.
- question id를 수정모드와 create모드를 분기하여 id값을 set하도록 하였습니다.