### PR TITLE
Fix(DK-481): 퀴즈 만들기 페이지 진입 시 도서 선택 전역 데이터 초기화 처리 fix

### DIFF
--- a/src/pages/CreateQuiz/index.tsx
+++ b/src/pages/CreateQuiz/index.tsx
@@ -52,7 +52,8 @@ export default function Index() {
 
   const { data: studyGroupDetail, isLoading: isStudyGroupLoading } = useQuery({
     queryKey: ["studyGroupDetail", prevQuiz?.studyGroupId],
-    queryFn: () => studyGroupService.fetchStudyGroup(prevQuiz?.studyGroupId ?? -1),
+    queryFn: () =>
+      studyGroupService.fetchStudyGroup(prevQuiz?.studyGroupId ?? -1),
     enabled: isEditMode && !!prevQuiz?.studyGroupId,
   });
 
@@ -91,8 +92,6 @@ export default function Index() {
             profileImageUrl: studyGroupDetail?.profileImageUrl,
           };
         }
-
-
 
         let selectOptions: SelectOptionType[];
         prevQuiz?.questions.forEach((question) => {
@@ -210,9 +209,9 @@ export default function Index() {
     isEditMode ? setCurrentStep(2) : setCurrentStep(0);
     resetQuizState();
     return () => {
-      if (isEditMode) {
-        resetBookState();
-      }
+      // if (isEditMode) {
+      resetBookState();
+      // }
     };
   }, []);
 

--- a/src/store/quizAtom.ts
+++ b/src/store/quizAtom.ts
@@ -55,8 +55,7 @@ export const isQuestionsWrittenAtom = atom(
 
 // 공유 설정 단계 완료 여부 Atom
 export const isSetAtom = atom(
-  (get) =>
-    get(quizCreationInfoAtom).viewScope !== null,
+  (get) => get(quizCreationInfoAtom).viewScope !== null,
   //&& get(quizCreationInfoAtom).editScope !== null,
   (get, set, update: boolean) => {
     const quizCreationInfo = get(quizCreationInfoAtom);
@@ -83,9 +82,8 @@ export const resetQuizCreationStateAtom = atom(null, (get, set) => {
   // book은 유지
   set(quizCreationInfoAtom, {
     ...initialQuizCreationInfo,
-    book: currentBook,
+    ...(currentBook ? { book: currentBook } : {}),
   });
-
   set(isQuizNextButtonEnabledAtom, initialIsQuizNextButtonEnabled);
   set(errorModalTitleAtom, initialErrorModalTitle);
   set(selectedOptionsAtom, initialSelectedOptions);


### PR DESCRIPTION
- 스터디그룹, 도서선택 전역 데이터 제거 안되는 문제 (퀴즈 만들기 페이지를 나갔다가 다시 들어와도 데이터가 유지됨)
- 스터디그룹은 선택되지 않아도 다음 버튼 활성화되어있는 게 맞기 때문에 도서 선택 초기화 처리만 수정했습니다.
- 기존에 edit 모드에서만 resetBookState()를 호출하도록 했던 조건문을 제거했는데, 이렇게 변경해도 되는지 확인 부탁드립니다!