### PR TITLE
Fix(DK-479): 닉네임 수정 후 프로필 사진이 안보이는 문제 수정

### DIFF
--- a/src/pages/MyPage/composite/accountSetting/EditMyInfo/EditMyInfo.tsx
+++ b/src/pages/MyPage/composite/accountSetting/EditMyInfo/EditMyInfo.tsx
@@ -25,6 +25,16 @@ export default function EditMyInfo() {
 
   const [profileImage, setProfileImage] =
     useState<ProfileImageState>(defaultProfileState);
+
+  useEffect(() => {
+    const profileImgState: ProfileImageState = {
+      url: currentUser?.profileImage ?? defaultImage,
+      file: null,
+    };
+    setProfileImage(profileImgState);
+  }, [currentUser?.profileImage]);
+
+
   const {
     value,
     onChange,
@@ -70,6 +80,9 @@ export default function EditMyInfo() {
       uploadImage(arg);
     }
   }, [profileImage.file]);
+
+
+
 
   return (
     <>


### PR DESCRIPTION
- 닉네임 수정후 유저 정보를 다시 fetch하는 과정에서, currentUser의 프로필이미지 값이 잠시 undefined 되어 생기는 문제로 파악됩니다.
- useEffect의 의존성배열에 프로필이미지 url값을 전달하여 임시적으로 문제를 해결했습니다
- 유저 정보를 업데이트하는 hook 로직이 별로 마음에 안들어서.. 배포 이후 수정해두겠습니다..