### PR TITLE
Fix(DK-509): 퀴즈작성 "퀴즈 스텝 간 이동" 시 퀴즈 폼 데이터들이 초기화 되는 문제 수정

### DIFF
--- a/src/pages/CreateQuiz/composite/QuizWriteForm/QuizWriteForm.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/QuizWriteForm.tsx
@@ -10,7 +10,7 @@ import { AnswerType } from "@/types/QuizType";
 import React from "react";
 import { useAtom } from "jotai";
 import { QuizCreationType } from "@/types/QuizType";
-import { quizCreationInfoAtom } from "@/store/quizAtom";
+import { isFirstVisitAtom, quizCreationInfoAtom } from "@/store/quizAtom";
 import {
   closestCenter,
   DndContext,
@@ -117,16 +117,24 @@ const QuizWriteForm = React.memo(() => {
 
     const [questionForms, setQuestionForms] =
       useState<QuestionFormType[]>(setInitialForms());
+    const [isFirstVisit] = useAtom(isFirstVisitAtom);
 
     const [isInitialized, setIsInitialized] = useState<boolean>(false);
     useEffect(() => {
-      if (isInitialized) {
+      const isFirstVisitInLocalStorageState =
+        localStorage.getItem("firstVisit") !== "false";
+
+      if (isInitialized || !isFirstVisitInLocalStorageState) {
+        setIsInitialized(true);
         return;
       }
-      // 초기화
+
+      // 가이드라인 단계 완료(로컬 스토리지 첫 방문 여부가 아직 "true"일 경우) 후 퀴즈 질문폼 초기화
       setQuestionForms([]);
       setIsInitialized(true);
-    }, [quizCreationInfo, isInitialized]);
+      // 방문한 사용자로 표시
+      localStorage.setItem("firstVisit", "false");
+    }, [isFirstVisit]);
 
     const handleDragStart = (event: DragStartEvent) => {
       const { active } = event;
@@ -248,9 +256,7 @@ const QuizWriteForm = React.memo(() => {
           문제 추가하기
         </Button>
       </section>
-    ) : (
-      <div>됴잉</div>
-    );
+    ) : null;
   }
 });
 

--- a/src/pages/CreateQuiz/composite/QuizWriteGuideBubble/QuizWriteGuideBubble.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteGuideBubble/QuizWriteGuideBubble.tsx
@@ -16,11 +16,12 @@ export default function QuizWriteGuideBubble({
   const [currentQuizGuideStep, setCurrentQuizGuideStep] =
     useAtom(quizGuideStepAtom);
   const totalStep = 3;
+
   const handleNextButtonClick = () => {
     setCurrentQuizGuideStep((prev) => prev + 1);
     if (currentQuizGuideStep == totalStep) {
       // 방문한 사용자로 표시
-      localStorage.setItem("firstVisit", "false");
+      // localStorage.setItem("firstVisit", "false");
       setIsFirstVisit(false);
     }
   };


### PR DESCRIPTION
- https://github.com/DOK-BARO/client/pull/283#discussion_r1942168449 언급해주셨던 문제 수정했습니다!
- 퀴즈 작성 가이드라인을 표시할 때, 문제를 폼에 추가해서 가이드라인을 보여줘야 했기 때문에 가이드라인이 끝난 후에 퀴즈 작성 폼을 초기화해줘야 했습니다. 그러나 조건문을 제대로 설정하지 않아, 퀴즈 작성 가이드라인 종료 후 한 번만 실행되어야 할 초기화 로직이 퀴즈 폼이 업데이트될 때마다 실행되며 폼 데이터가 계속 초기화되는 문제가 있었습니다. 이를 수정하였습니다.