### PR TITLE
Fix(DK-514): "다음버튼" 상태를 한 곳에서 변경하도록 구현

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -32,3 +32,12 @@ export const BOOK_QUIZ_OPTION_MAX_LENGTH = 5;
 
 export const EXTERNAL_SERVICE_INTRODUCTION_PAGE =
   "https://maddening-radar-044.notion.site/a13ecec47e8c4d789b6939c01733749e?pvs=4";
+
+export const QUIZ_CREATION_STEP = {
+  STUDY_GROUP_SELECT: 0,
+  BOOK_SELECT: 1,
+  QUIZ_BASIC_INFO: 2,
+  QUIZ_BASIC_INFO_FORM: 2.1,
+  QUIZ_WRITE_FORM: 2.2,
+  SETTING: 3,
+};

--- a/src/pages/CreateQuiz/composite/QuizBasicInfoForm/QuizBasicInfoForm.tsx
+++ b/src/pages/CreateQuiz/composite/QuizBasicInfoForm/QuizBasicInfoForm.tsx
@@ -1,23 +1,14 @@
-import React, { useEffect } from "react";
-import { useAtom } from "jotai";
+import React from "react";
 import Input from "@/components/atom/Input/Input";
 import Textarea from "@/components/atom/Textarea/Textarea";
 import styles from "./_quiz_basic_info_form.module.scss";
 import useInput from "@/hooks/useInput.ts";
 import useAutoResizeTextarea from "@/hooks/useAutoResizeTextArea";
-import { isQuizNextButtonEnabledAtom } from "@/store/quizAtom";
 import useUpdateQuizCreationInfo from "@/hooks/useUpdateQuizCreationInfo";
 
 function QuizBasicInfoForm() {
   const { quizCreationInfo, updateQuizCreationInfo } =
     useUpdateQuizCreationInfo();
-  console.log(quizCreationInfo);
-  console.log(quizCreationInfo.title);
-
-  const [, setIsQuizNextButtonEnabled] = useAtom<boolean>(
-    isQuizNextButtonEnabledAtom,
-  );
-
   const titleMaxLength = 127;
   const descriptionMaxLength = 150;
   const { value: titleInputValue, onChange: onTitleChange } = useInput(
@@ -28,12 +19,6 @@ function QuizBasicInfoForm() {
     onChange: onDescriptionChange,
     textareaRef,
   } = useAutoResizeTextarea(quizCreationInfo.description ?? "", 56, 3);
-
-  useEffect(() => {
-    const disable =
-      titleInputValue.trim() === "" || descriptionTextareaValue.trim() === "";
-    setIsQuizNextButtonEnabled(!disable);
-  }, [titleInputValue, descriptionTextareaValue]);
 
   const handleDescriptionChange = (
     e: React.ChangeEvent<HTMLTextAreaElement>,
@@ -66,7 +51,6 @@ function QuizBasicInfoForm() {
           placeholder="퀴즈 설명"
           maxLength={descriptionMaxLength}
           textAreaRef={textareaRef}
-          // className={styles["quiz-basic-info-description-text-area"]}
           maxLengthShow
           fullWidth
           size="large"

--- a/src/pages/CreateQuiz/composite/QuizBookSectionForm/QuizBookSelectionForm/QuizBookSelectionForm.tsx
+++ b/src/pages/CreateQuiz/composite/QuizBookSectionForm/QuizBookSelectionForm/QuizBookSelectionForm.tsx
@@ -8,8 +8,6 @@ import { Search } from "@/svg/Search";
 import { gray60, gray90 } from "@/styles/abstracts/colors";
 import useDebounce from "@/hooks/useDebounce";
 import { BookType } from "@/types/BookType";
-import { useAtom } from "jotai";
-import { isQuizNextButtonEnabledAtom } from "@/store/quizAtom";
 import useUpdateQuizCreationInfo from "@/hooks/useUpdateQuizCreationInfo";
 import { bookService } from "@/services/server/bookService";
 import { BookListItem } from "../BookListItem/BookListItem";
@@ -22,9 +20,6 @@ export default function QuizBookSelectionForm() {
   const [isSearchInputClicked, setIsSearchInputClicked] =
     useState<boolean>(false);
   const inputRef = useRef<HTMLDivElement>(null);
-  const [, setIsQuizNextButtonEnabled] = useAtom<boolean>(
-    isQuizNextButtonEnabledAtom,
-  );
   const {
     value: searchValue,
     onChange: onChangeSearchValue,
@@ -61,13 +56,6 @@ export default function QuizBookSelectionForm() {
   }, [debouncedSearchValue, refetch]);
 
   const isBookSearching = isLoading || isFetching;
-
-  useEffect(() => {
-    if (!selectedBook) {
-      setIsQuizNextButtonEnabled(false);
-    }
-  }, []);
-
   useOutsideClick([inputRef], () => setIsSearchInputClicked(false));
 
   const handleSearchBook = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -82,9 +70,6 @@ export default function QuizBookSelectionForm() {
     setSelectedBook(book);
     resetSearchValueInput();
     updateQuizCreationInfo("book", book);
-
-    // 책이 선택되면 버튼 enabled
-    setIsQuizNextButtonEnabled(true);
   };
 
   // 인풋창 클릭

--- a/src/pages/CreateQuiz/composite/QuizSettingsForm/QuizSettingsForm.tsx
+++ b/src/pages/CreateQuiz/composite/QuizSettingsForm/QuizSettingsForm.tsx
@@ -1,6 +1,4 @@
 import { useEffect, useState } from "react";
-import { isQuizNextButtonEnabledAtom } from "@/store/quizAtom";
-import { useAtom } from "jotai";
 import useUpdateQuizCreationInfo from "@/hooks/useUpdateQuizCreationInfo";
 import {
   QuizCreationType,
@@ -17,14 +15,6 @@ interface SelectedOptions {
 export default function QuizSettingsForm() {
   const { quizCreationInfo, updateQuizCreationInfo } =
     useUpdateQuizCreationInfo();
-  const [, setIsQuizNextButtonEnabled] = useAtom<boolean>(
-    isQuizNextButtonEnabledAtom,
-  );
-
-  // 다음 버튼 초기화
-  useEffect(() => {
-    setIsQuizNextButtonEnabled(false);
-  }, []);
 
   const [selectedOptions, setSelectedOptions] = useState<SelectedOptions>({
     "view-access": quizCreationInfo.viewScope
@@ -57,18 +47,6 @@ export default function QuizSettingsForm() {
       [settingName]: label,
     });
   };
-
-  // 모든 항목이 선택되었는지 체크
-  useEffect(() => {
-    if (!quizSettings) {
-      return;
-    }
-    const isAllSelected = quizSettings.every(
-      (setting) => selectedOptions[setting.name] !== null,
-    );
-
-    setIsQuizNextButtonEnabled(isAllSelected);
-  }, [Object.values(selectedOptions)]);
 
   return (
     <>
@@ -108,27 +86,4 @@ const getQuizSettings = (isStudyGroupSelected: boolean): QuizSettingType[] => [
 
     icon: "/assets/svg/quizSettingForm/view.svg",
   },
-  // {
-  //   title: "편집 권한",
-  //   name: "edit-access",
-  //   options: isStudyGroupSelected
-  //     ? [
-  //         {
-  //           label: "스터디원만",
-  //           description: "스터디원이 이 퀴즈를 편집할 수 있습니다.",
-  //         },
-  //         {
-  //           label: "나만",
-  //           description: "나만 이 퀴즈를 편집할 수 있습니다.",
-  //         },
-  //       ]
-  //     : [
-  //         {
-  //           label: "나만",
-  //           description: "나만 이 퀴즈를 보고 풀 수 있습니다.",
-  //         },
-  //       ],
-
-  //   icon: "/assets/svg/quizSettingForm/edit.svg",
-  // },
 ];

--- a/src/pages/CreateQuiz/index.tsx
+++ b/src/pages/CreateQuiz/index.tsx
@@ -11,6 +11,7 @@ import {
   isFirstVisitAtom,
   openErrorModalAtom,
   quizCreationInfoAtom,
+  quizCreationStepAtom,
   quizGuideStepAtom,
   resetQuizCreationStateAtom,
   stepsCompletionStatusAtom,
@@ -38,6 +39,7 @@ import ROUTES from "@/data/routes.ts";
 import { preventLeaveModalAtom } from "@/store/quizAtom.ts";
 import useUpdateQuizCreationInfo from "@/hooks/useUpdateQuizCreationInfo.ts";
 import QuizWriteGuideForm from "./composite/QuizWriteForm/QuizWriteGuideForm.tsx";
+import { QUIZ_CREATION_STEP } from "@/data/constants.ts";
 
 export default function Index() {
   const { id } = useParams();
@@ -175,7 +177,7 @@ export default function Index() {
   const steps: Step[] = useMemo(
     () => [
       {
-        order: 0,
+        order: QUIZ_CREATION_STEP.STUDY_GROUP_SELECT,
         icon: "👥",
         title: "스터디 그룹 선택",
         description: "퀴즈를 풀 스터디 그룹을 만들거나 선택해주세요.",
@@ -183,7 +185,7 @@ export default function Index() {
         isDone: completionStatus.isStudyGroupSelected,
       },
       {
-        order: 1,
+        order: QUIZ_CREATION_STEP.BOOK_SELECT,
         icon: "📚",
         title: "도서 선택",
         description: "퀴즈를 내고자 하는 도서를 선택해주세요.",
@@ -191,18 +193,18 @@ export default function Index() {
         isDone: completionStatus.isBookSelected,
       },
       {
-        order: 2,
+        order: QUIZ_CREATION_STEP.QUIZ_BASIC_INFO,
         icon: "🏆",
         title: "퀴즈 작성",
         subSteps: [
           {
-            order: 2.1,
+            order: QUIZ_CREATION_STEP.QUIZ_BASIC_INFO_FORM,
             title: "퀴즈 기본 정보",
             description: "퀴즈 이름과 설명을 작성해주세요.",
             formComponent: () => <MemoizedQuizBasicInfoForm />,
           },
           {
-            order: 2.2,
+            order: QUIZ_CREATION_STEP.QUIZ_WRITE_FORM,
             title: "문제 작성",
             description:
               "퀴즈의 질문을 작성한 후, 답안을 클릭하여 설정해주세요.",
@@ -217,7 +219,7 @@ export default function Index() {
         isDone: completionStatus.isQuestionsWritten,
       },
       {
-        order: 3,
+        order: QUIZ_CREATION_STEP.SETTING,
         icon: "🔗",
         title: "퀴즈 공유 설정",
         // description: "퀴즈를 볼 수 있는 사람과 편집 권한을 설정해 주세요.",
@@ -229,7 +231,7 @@ export default function Index() {
     [completionStatus, isFirstVisit, isEditMode],
   );
 
-  const [currentStep, setCurrentStep] = useState<number>(0);
+  const [currentStep, setCurrentStep] = useAtom(quizCreationStepAtom);
   const [errorModalTitle] = useAtom(errorModalTitleAtom);
   const { isModalOpen, openModal, closeModal } = useModal();
   const [, setOpenErrorModal] = useAtom(openErrorModalAtom);
@@ -300,18 +302,11 @@ export default function Index() {
         <div className={styles.layer} />
       ) : null}
       <h2 className={styles["sr-only"]}>퀴즈 등록</h2>
-      <QuizCreationSteps
-        isEditMode={isEditMode}
-        steps={steps}
-        currentStep={currentStep}
-        setCurrentStep={setCurrentStep}
-      />
+      <QuizCreationSteps isEditMode={isEditMode} steps={steps} />
       <QuizCreationFormLayout
         isEditMode={isEditMode}
         editQuizId={quizId ?? ""}
         steps={steps}
-        currentStep={currentStep}
-        setCurrentStep={setCurrentStep}
         blocker={blocker}
       />
       {/* TODO: 컴포넌트 분리 */}

--- a/src/pages/CreateQuiz/layout/QuizCreationFormLayout/QuizCreationFormLayout.tsx
+++ b/src/pages/CreateQuiz/layout/QuizCreationFormLayout/QuizCreationFormLayout.tsx
@@ -8,6 +8,7 @@ import {
   createdQuizIdAtom,
   isQuizNextButtonEnabledAtom,
   quizCreationInfoAtom,
+  quizCreationStepAtom,
 } from "@/store/quizAtom";
 import {
   QuizCreationType,
@@ -23,7 +24,6 @@ import { useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import ROUTES from "@/data/routes";
 import { invalidQuestionFormIdAtom } from "@/store/quizAtom";
-import React from "react";
 import { queryClient } from "@/services/server/queryClient";
 import { studyGroupKeys } from "@/data/queryKeys";
 import { SelectOptionType } from "@/types/QuizType";
@@ -34,20 +34,18 @@ export default function QuizCreationFormLayout({
   isEditMode,
   editQuizId,
   steps,
-  currentStep,
-  setCurrentStep,
   blocker,
 }: {
   isEditMode: boolean;
   editQuizId?: string;
   steps: Step[];
-  currentStep: number;
-  setCurrentStep: React.Dispatch<React.SetStateAction<number>>;
   blocker: Blocker;
 }) {
   const navigate = useNavigate();
-  const [isQuizNextButtonEnabled, setIsQuizNextButtonEnabled] =
-    useAtom<boolean>(isQuizNextButtonEnabledAtom);
+  const [currentStep, setCurrentStep] = useAtom(quizCreationStepAtom);
+  const [isQuizNextButtonEnabled] = useAtom<boolean>(
+    isQuizNextButtonEnabledAtom,
+  );
   const [quizCreationInfo] = useAtom<QuizCreationType>(quizCreationInfoAtom);
   const [, setErrorModalTitle] = useAtom(errorModalTitleAtom);
   const [openModal] = useAtom(openErrorModalAtom);
@@ -81,14 +79,6 @@ export default function QuizCreationFormLayout({
   //   }, 60000);
   //   return () => clearInterval(intervalId);
   // }, []);
-
-  useEffect(() => {
-    if (!quizCreationInfo?.questions?.length) {
-      setIsQuizNextButtonEnabled(false);
-    } else {
-      setIsQuizNextButtonEnabled(true);
-    }
-  }, [quizCreationInfo.questions?.length, currentStep]);
 
   const getCurrentStep = (): Step => {
     const step = steps[currentStep];

--- a/src/pages/CreateQuiz/layout/QuizCreationSteps/QuizCreationSteps.tsx
+++ b/src/pages/CreateQuiz/layout/QuizCreationSteps/QuizCreationSteps.tsx
@@ -9,18 +9,17 @@ import {
   systemSuccess,
 } from "@/styles/abstracts/colors.ts";
 import { CheckEllipse } from "@/svg/CheckEllipse";
+import { useAtom } from "jotai";
+import { quizCreationStepAtom } from "@/store/quizAtom";
 
 export default function QuizCreationSteps({
   isEditMode,
   steps,
-  currentStep,
-  setCurrentStep,
 }: {
   isEditMode: boolean;
   steps: Step[];
-  currentStep: number;
-  setCurrentStep: React.Dispatch<React.SetStateAction<number>>;
 }) {
+  const [currentStep, setCurrentStep] = useAtom(quizCreationStepAtom);
   const onChangeStep = (e: React.MouseEvent<HTMLButtonElement>) => {
     const currentStepButtonValue = e.currentTarget.value;
     steps.forEach((step) => {

--- a/src/store/quizAtom.ts
+++ b/src/store/quizAtom.ts
@@ -1,3 +1,4 @@
+import { QUIZ_CREATION_STEP } from "@/data/constants";
 import { QuizCreationType } from "@/types/QuizType";
 import { atom } from "jotai";
 
@@ -17,7 +18,6 @@ const initialQuizCreationInfo: QuizCreationType = {
 const initialSelectedOptions: string[] = [];
 const initialQuizId: number | undefined = undefined;
 const initialErrorModalTitle = "";
-const initialIsQuizNextButtonEnabled = true; // 퀴즈 생성 단계 다음 버튼의 enabled 여부를 저장
 
 {
   /* Atom 정의 */
@@ -25,15 +25,43 @@ const initialIsQuizNextButtonEnabled = true; // 퀴즈 생성 단계 다음 버�
 export const quizCreationInfoAtom = atom<QuizCreationType>(
   initialQuizCreationInfo,
 );
-export const isQuizNextButtonEnabledAtom = atom<boolean>(
-  initialIsQuizNextButtonEnabled,
-);
+
+// 퀴즈 다음 버튼 활성화 여부 Atom
+export const isQuizNextButtonEnabledAtom = atom<boolean>((get) => {
+  const step = get(quizCreationStepAtom);
+  const quizInfo = get(quizCreationInfoAtom);
+  console.log(quizInfo);
+
+  switch (step) {
+    case QUIZ_CREATION_STEP.STUDY_GROUP_SELECT:
+      return true;
+    case QUIZ_CREATION_STEP.BOOK_SELECT:
+      return quizInfo.book !== null;
+    case QUIZ_CREATION_STEP.QUIZ_BASIC_INFO:
+    case QUIZ_CREATION_STEP.QUIZ_BASIC_INFO_FORM:
+      return (
+        quizInfo.title !== null &&
+        quizInfo.description !== null &&
+        !!quizInfo.title?.length &&
+        !!quizInfo?.description.length
+      );
+    case QUIZ_CREATION_STEP.QUIZ_WRITE_FORM:
+      return quizInfo.questions !== null && quizInfo.questions.length > 0;
+    case QUIZ_CREATION_STEP.SETTING:
+      return quizInfo.viewScope !== null;
+    default:
+      return true;
+  }
+});
+
+export const quizCreationStepAtom = atom<number>(0); // 퀴즈 작성 단계
+
 export const errorModalTitleAtom = atom<string>(initialErrorModalTitle);
 export const openErrorModalAtom = atom<() => void>();
 export const selectedOptionsAtom = atom<string[]>(initialSelectedOptions);
 export const createdQuizIdAtom = atom<number | undefined>(initialQuizId);
 
-// 스터디 선택 단계 완료 여부 Atom
+// 스터디 선택 단계 완료 여부 Atom (진행단계 체크UI)
 export const isStudyGroupSelectedAtom = atom(
   (get) => get(quizCreationInfoAtom).studyGroup !== null,
 );
@@ -56,7 +84,6 @@ export const isQuestionsWrittenAtom = atom(
 // 공유 설정 단계 완료 여부 Atom
 export const isSetAtom = atom(
   (get) => get(quizCreationInfoAtom).viewScope !== null,
-  //&& get(quizCreationInfoAtom).editScope !== null,
   (get, set, update: boolean) => {
     const quizCreationInfo = get(quizCreationInfoAtom);
     set(quizCreationInfoAtom, {
@@ -86,7 +113,6 @@ export const resetQuizCreationStateAtom = atom(null, (get, set) => {
     ...(currentBook ? { book: currentBook } : {}),
     ...(currentStudyGroup ? { studyGroup: currentStudyGroup } : {}),
   });
-  set(isQuizNextButtonEnabledAtom, initialIsQuizNextButtonEnabled);
   set(errorModalTitleAtom, initialErrorModalTitle);
   set(selectedOptionsAtom, initialSelectedOptions);
   set(createdQuizIdAtom, initialQuizId);


### PR DESCRIPTION
- 현재 스탭 값을 (currentStep) 전역으로 관리하도록 Atom생성하였습니다.
- "다음버튼" 상태를 정의한 곳에서 currentStep에 따라 퀴즈 작성값 Atom을 확인하여 다음 버튼이 활성/비활성 되도록 구현하였습니다.

#### TODO
"다음버튼" 상태를 progress 에서도 사용 할 예정입니다