### PR TITLE
Fix(DK-529): safari 퀴즈 만들기 옵션 삭제 안되는 오류 수정

### DIFF
--- a/src/components/atom/Checkbox/Checkbox.tsx
+++ b/src/components/atom/Checkbox/Checkbox.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styles from "./_checkbox.module.scss";
 import { Close } from "@/svg/Close";
-import { gray90 } from "@/styles/abstracts/colors";
+import { gray40, gray70 } from "@/styles/abstracts/colors";
 import Textarea from "../Textarea/Textarea";
 import Button from "../Button/Button";
 import { useState } from "react";
@@ -112,9 +112,6 @@ export default function CheckBox({
           <div className={styles["option-label-value"]}>{value}</div>
         )}
         <Button
-          className={
-            styles[type === "checkbox-writing" ? "visible" : "invisible"]
-          }
           onClick={() => {
             deleteOption(parseInt(id));
           }}
@@ -122,17 +119,13 @@ export default function CheckBox({
             <Close
               width={20}
               height={20}
-              stroke={gray90}
+              stroke={type === "checkbox-writing" ? gray70 : gray40}
               strokeWidth={2}
               alt="옵션 삭제하기"
             />
           }
           iconOnly
         />
-
-        {type !== "checkbox-writing" && (
-          <div className={styles["empty-icon"]}></div>
-        )}
       </label>
     </div>
   );

--- a/src/components/atom/Checkbox/_checkbox.module.scss
+++ b/src/components/atom/Checkbox/_checkbox.module.scss
@@ -41,13 +41,6 @@
   background-color: $secondary;
 }
 
-.visible {
-  opacity: 1;
-}
-.invisible {
-  opacity: 0;
-}
-
 .option-label-textarea {
   font-size: $font-size-medium;
   font-weight: $font-weight-regular;

--- a/src/components/atom/RadioOption/RadioOption.tsx
+++ b/src/components/atom/RadioOption/RadioOption.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styles from "./_radio_option.module.scss";
 import { RadioOptionType } from "@/types/RadioTypes";
 import { Close } from "@/svg/Close";
-import { gray90 } from "@/styles/abstracts/colors";
+import { gray40, gray70 } from "@/styles/abstracts/colors";
 import Textarea from "@/components/atom/Textarea/Textarea";
 import "highlight.js/styles/xcode.css";
 import Button from "../Button/Button";
@@ -129,15 +129,12 @@ const RadioOption: React.FC<RadioOptionProps> = ({
 
         <Button
           iconOnly
-          className={
-            styles[type === "option-writing" ? "visible" : "invisible"]
-          }
           icon={
             <Close
               alt="옵션 삭제하기"
               width={20}
               height={20}
-              stroke={gray90}
+              stroke={type === "option-writing" ? gray70 : gray40}
               strokeWidth={2}
             />
           }
@@ -146,10 +143,6 @@ const RadioOption: React.FC<RadioOptionProps> = ({
           }}
           disabled={isFirstVisit && !isEditMode && currentQuizGuideStep == 2}
         />
-
-        {type !== "option-writing" && (
-          <div className={styles["empty-icon"]}></div>
-        )}
       </label>
     </div>
   );

--- a/src/components/atom/RadioOption/_radio_option.module.scss
+++ b/src/components/atom/RadioOption/_radio_option.module.scss
@@ -168,13 +168,6 @@
   white-space: pre-line;
 }
 
-.visible {
-  opacity: 1;
-}
-.invisible {
-  opacity: 0;
-}
-
 .empty-icon {
   width: 20px;
   height: 20px;

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/OXQuestionTemplate.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/OXQuestionTemplate.tsx
@@ -59,7 +59,7 @@ export const OXQuestionTemplate: FC<{
         return (
           <div key={option.id} className={styles["option-container"]}>
             <RadioOption
-              radioGroupName={questionFormId?.toString()!}
+              radioGroupName={questionFormId!.toString()}
               option={option}
               checked={isChecked}
               onChange={handleRadioGroupChange}

--- a/src/styles/abstracts/_mixins.scss
+++ b/src/styles/abstracts/_mixins.scss
@@ -32,6 +32,7 @@
   font-family: inherit;
   color: $gray-90;
   width: 100%;
+  line-height: 1.5;
 
   &::placeholder {
     color: $gray-60;


### PR DESCRIPTION
- 옵션 삭제 버튼 스타일링 수정하면서 같이 해결되었습니다.
- Textarea에 line-height가 명시되지 않아 스타일링이 이상하게 적용되던 부분을 명시적으로 지정하여 수정하였습니다.