### PR TITLE
Release 1.2.3 Style, Feat(DK-567): 2/15 알파테스트 css 수정사항 fix

### DIFF
--- a/src/components/atom/RadioOption/RadioOption.tsx
+++ b/src/components/atom/RadioOption/RadioOption.tsx
@@ -159,6 +159,7 @@ const RadioOption: React.FC<RadioOptionProps> = ({
               disabled={
                 isFirstVisit && !isEditMode && currentQuizGuideStep == 2
               }
+              className={styles["guide-option-delete-button"]}
             />
           )}
       </label>

--- a/src/components/atom/RadioOption/_radio_option.module.scss
+++ b/src/components/atom/RadioOption/_radio_option.module.scss
@@ -178,3 +178,10 @@
   font-weight: $font-weight-regular;
   line-height: 150%;
 }
+
+.guide-option-delete-button {
+  &:disabled {
+    background-color: transparent;
+    border: none;
+  }
+}

--- a/src/pages/BookDetail/composite/QuizItem/_quiz_item.module.scss
+++ b/src/pages/BookDetail/composite/QuizItem/_quiz_item.module.scss
@@ -10,6 +10,7 @@
   border-radius: 8px;
   gap: 40px;
   cursor: pointer;
+  min-width: 0;
 }
 .content {
   display: flex;
@@ -41,6 +42,7 @@
 }
 
 .quiz-title {
+  @include text-ellipsis;
   font-size: $font-size-xlarge;
   font-weight: $font-weight-bold;
 }

--- a/src/pages/BookDetail/composite/QuizListSection/QuizListSection.tsx
+++ b/src/pages/BookDetail/composite/QuizListSection/QuizListSection.tsx
@@ -12,7 +12,7 @@ import useNavigateWithParams from "@/hooks/useNavigateWithParams.ts";
 import ListFilter from "@/components/composite/ListFilter/ListFilter.tsx";
 import { NoDataSection } from "@/components/composite/NoDataSection/NoDataSection.tsx";
 import { paginationAtom } from "@/store/paginationAtom.ts";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import ROUTES from "@/data/routes.ts";
 import { quizzesLengthAtom } from "@/store/quizAtom.ts";
 import useLoginAction from "@/hooks/useLoginAction.ts";
@@ -98,6 +98,9 @@ export default function QuizListSection({ bookId }: { bookId: string }) {
   const handleGoToQuizDetail = (quizId: number) => {
     handleAuthenticatedAction(() => navigate(ROUTES.QUIZ_DETAIL(quizId)));
   };
+  const shouldRenderPagination = useMemo(() => {
+    return (totalPagesLength ?? 0) > 0;
+  }, [totalPagesLength]);
 
   if (isLoading) {
     return <LoadingSpinner width={40} pageCenter />;
@@ -128,7 +131,7 @@ export default function QuizListSection({ bookId }: { bookId: string }) {
             />
           ))}
       </div>
-      {totalPagesLength && totalPagesLength > 0 && (
+      {shouldRenderPagination ? (
         <Pagination
           type="queryString"
           parentPage="book"
@@ -136,7 +139,7 @@ export default function QuizListSection({ bookId }: { bookId: string }) {
           paginationState={paginationState}
           setPaginationState={setPaginationState}
         />
-      )}
+      ) : null}
     </section>
   );
 }

--- a/src/pages/BookList/composite/Lnb/Lnb.tsx
+++ b/src/pages/BookList/composite/Lnb/Lnb.tsx
@@ -59,7 +59,7 @@ export default function LNB({
                   />
                 }
                 iconOnly
-                onClick={() => navigate(ROUTES.ROOT)}
+                onClick={() => navigate(ROUTES.BOOK_LIST)}
               />
               <Button
                 size="xsmall"
@@ -77,39 +77,38 @@ export default function LNB({
         <ul className={styles["category-list"]}>
           {!categoryId
             ? categories?.map((category) => (
-              <li key={category.id} className={styles["category-item"]}>
-                <Button
-                  color="transparent"
-                  size="xsmall"
-                  // fullWidth
-                  value={category.id.toString()}
-                  className={styles["category-item-button"]}
-                  onClick={() => handleClick(category.id.toString())}
-                >
-                  {category.name}
-                </Button>
-              </li>
-            ))
-            : categories
-              .find((item) => item.id === parentCategoryInfo?.id)
-              ?.details?.map((categoryDetail) => (
-                <li
-                  key={categoryDetail.id}
-                  className={styles["category-detail-item"]}
-                >
+                <li key={category.id} className={styles["category-item"]}>
                   <Button
-                    size="xsmall"
                     color="transparent"
-                    className={`${styles["category-detail-item-button"]} ${
-                      categoryId === categoryDetail.id ? styles.selected : ""
-                    }`}
-                    value={categoryDetail.id.toString()}
-                    onClick={() => handleClick(categoryDetail.id.toString())}
+                    size="xsmall"
+                    value={category.id.toString()}
+                    className={styles["category-item-button"]}
+                    onClick={() => handleClick(category.id.toString())}
                   >
-                    {categoryDetail.name}
+                    {category.name}
                   </Button>
                 </li>
-              ))}
+              ))
+            : categories
+                .find((item) => item.id === parentCategoryInfo?.id)
+                ?.details?.map((categoryDetail) => (
+                  <li
+                    key={categoryDetail.id}
+                    className={styles["category-detail-item"]}
+                  >
+                    <Button
+                      size="xsmall"
+                      color="transparent"
+                      className={`${styles["category-detail-item-button"]} ${
+                        categoryId === categoryDetail.id ? styles.selected : ""
+                      }`}
+                      value={categoryDetail.id.toString()}
+                      onClick={() => handleClick(categoryDetail.id.toString())}
+                    >
+                      {categoryDetail.name}
+                    </Button>
+                  </li>
+                ))}
         </ul>
       </div>
     </nav>

--- a/src/pages/BookList/layout/BookListLayout/BookListLayout.tsx
+++ b/src/pages/BookList/layout/BookListLayout/BookListLayout.tsx
@@ -9,7 +9,7 @@ import {
   findTopParentCategoryInfo,
 } from "@/utils/findCategoryInfo";
 import Breadcrumb from "../../../../components/composite/Breadcrumb/Breadcrumb";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import Pagination from "@/components/composite/Pagination/Pagination";
 import { useAtom, useSetAtom } from "jotai";
 import {
@@ -93,10 +93,12 @@ export default function BookListLayout() {
 
   const books = booksData?.data;
   const endPageNumber = booksData?.endPageNumber;
+  const totalPagesLength = paginationState.totalPagesLength;
 
   // 마지막 페이지 번호 저장
   useEffect(() => {
-    if (endPageNumber && paginationState.totalPagesLength !== endPageNumber) {
+    if (endPageNumber && totalPagesLength !== endPageNumber) {
+      console.log(endPageNumber);
       setPaginationState((prev) => ({
         ...prev,
         totalPagesLength: endPageNumber,
@@ -128,6 +130,11 @@ export default function BookListLayout() {
     ? findCurrentCategoryInfo(categories, Number(category))
     : null;
 
+  const shouldRenderDataList = !isBooksLoading || booksData;
+  const shouldRenderPagination = useMemo(() => {
+    return (totalPagesLength ?? 0) > 0;
+  }, [totalPagesLength]);
+
   return (
     <section className={styles.container}>
       {isCategoriesLoading || !categories ? null : (
@@ -153,8 +160,8 @@ export default function BookListLayout() {
             filterOptions={filterOptions}
           />
         </div>
-        {isBooksLoading || !booksData ? null : <Outlet context={{ books }} />}
-        {paginationState.totalPagesLength ? (
+        {shouldRenderDataList ? <Outlet context={{ books }} /> : null}
+        {shouldRenderPagination ? (
           <Pagination
             type="queryString"
             parentPage="books"

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/MultipleChoiceQuestionTemplate.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/MultipleChoiceQuestionTemplate.tsx
@@ -95,7 +95,14 @@ export const MultipleChoiceQuestionTemplate: FC<{
   }, [isFirstVisit, isEditMode, currentQuizGuideStep]);
 
   return (
-    <fieldset className={styles["question-options"]}>
+    <fieldset
+      className={styles["question-options"]}
+      style={
+        isFirstVisit && !isEditMode && currentQuizGuideStep == 2
+          ? { position: "relative", zIndex: 999 }
+          : {}
+      }
+    >
       <QuizWriteGuideBubble
         marginTop={-85}
         text={

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionForm.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionForm.tsx
@@ -17,7 +17,7 @@ import { AnswerType, QuizQuestionType } from "@/types/QuizType";
 import QuestionTemplateTypeUtilButton from "./QuestionTemplateTypeUtilButton";
 import { OxQuiz } from "@/svg/QuizWriteForm/OXQuiz";
 import Button from "@/components/atom/Button/Button";
-import { gray90 } from "@/styles/abstracts/colors";
+import { gray60, gray90 } from "@/styles/abstracts/colors";
 import {
   errorMessageAtomFamily,
   invalidQuestionFormIdAtom,
@@ -390,7 +390,7 @@ export default function QuestionForm({
 
       <div className={styles["question-form-content"]}>
         <div className={styles["setting-container"]}>
-          {/* <Button
+          <Button
             icon={
               <ImageAdd
                 width={24}
@@ -401,7 +401,7 @@ export default function QuestionForm({
             }
             iconOnly
             className={styles["image-add-button"]}
-          /> */}
+          />
           <QuestionTemplateTypeUtilButton
             questionId={questionFormId}
             list={questionTemplates}

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionFormHeader.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionFormHeader.tsx
@@ -26,7 +26,11 @@ export default function QuestionFormHeader({
         data-allow-dnd="true"
         style={
           isFirstVisit && !isEditMode && currentQuizGuideStep == 3
-            ? { position: "relative", zIndex: 999 }
+            ? {
+                position: "relative",
+                zIndex: 999,
+                marginLeft: "-8px",
+              }
             : {}
         }
       >

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/_question_form.module.scss
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/_question_form.module.scss
@@ -30,7 +30,7 @@
     background-color: $gray-00;
     width: 40px;
     height: 40px;
-    margin-left: -8px;
+    // margin-left: -8px;
 
     @include flex(row, center);
     border-radius: 50%;

--- a/src/pages/CreateQuiz/composite/QuizWriteGuideBubble/_quiz_write_guide_bubble.module.scss
+++ b/src/pages/CreateQuiz/composite/QuizWriteGuideBubble/_quiz_write_guide_bubble.module.scss
@@ -5,8 +5,6 @@
   z-index: 999;
   left: 50%;
   transform: translateX(-50%);
-  // top: -85px;
-  // top: -150px;
   .guide {
     position: relative;
     background-color: $gray-00;

--- a/src/pages/MyPage/components/QuizItem/_quiz_item.module.scss
+++ b/src/pages/MyPage/components/QuizItem/_quiz_item.module.scss
@@ -9,6 +9,7 @@
   flex-direction: row;
   gap: 16px;
   height: 280px;
+  width: 420px;
 
   .left-container,
   .right-container {
@@ -43,8 +44,11 @@
       margin-bottom: 8px;
     }
     .title {
+      @include text-ellipsis;
       font-size: $font-size-large;
       font-weight: $font-weight-semibold;
+      min-width: 0;
+      width: 220px;
     }
     .copy-link {
       padding: 4px;
@@ -90,6 +94,7 @@
       color: $gray-70;
       font-size: $font-size-small;
       font-weight: $font-weight-regular;
+      @include text-ellipsis(5);
     }
 
     .button-container {

--- a/src/pages/MyPage/components/QuizItem/_quiz_item.module.scss
+++ b/src/pages/MyPage/components/QuizItem/_quiz_item.module.scss
@@ -27,11 +27,11 @@
       display: flex;
       justify-content: center;
       align-items: start;
-      height: 208px;
+      max-height: 210px;
 
       .img {
         max-width: 140px;
-        height: auto;
+        max-height: 100%;
         border-radius: 6px;
       }
     }

--- a/src/pages/MyPage/composite/MyMadeQuiz/MyMadeQuiz.tsx
+++ b/src/pages/MyPage/composite/MyMadeQuiz/MyMadeQuiz.tsx
@@ -9,7 +9,7 @@ import { myMadeQuizPaginationAtom } from "@/store/paginationAtom";
 import Pagination from "@/components/composite/Pagination/Pagination";
 import { FilterOptionType } from "@/components/composite/ListFilter/ListFilter";
 import { FetchMyQuizzesParams } from "@/types/ParamsType";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import ROUTES from "@/data/routes";
 import { MyMadeQuizzesFilterType } from "@/types/FilterType";
 import { myMadeQuizzesFilterAtom } from "@/store/filterAtom";
@@ -76,6 +76,10 @@ export default function MyMadeQuiz() {
 
   const myQuizzes = myQuizzesData?.data;
 
+  const shouldRenderPagination = useMemo(() => {
+    return (totalPagesLength ?? 0) > 0;
+  }, [totalPagesLength]);
+
   if (isLoading || !myQuizzes) {
     return <LoadingSpinner pageCenter width={40} />;
   }
@@ -92,14 +96,14 @@ export default function MyMadeQuiz() {
         filterCriteria={filterCriteria}
         filterOptions={filterOptions}
       />
-      {totalPagesLength && totalPagesLength > 0 && (
+      {shouldRenderPagination ? (
         <Pagination
           type="queryString"
           parentPage={"my/made-quiz"}
           paginationState={paginationState}
           setPaginationState={setPaginationState}
         />
-      )}
+      ) : null}
     </>
   );
 }

--- a/src/pages/MyPage/composite/SolvedQuiz/SolvedQuiz.tsx
+++ b/src/pages/MyPage/composite/SolvedQuiz/SolvedQuiz.tsx
@@ -9,7 +9,7 @@ import { mySolvedQuizPaginationAtom } from "@/store/paginationAtom";
 import Pagination from "@/components/composite/Pagination/Pagination";
 import { FilterOptionType } from "@/components/composite/ListFilter/ListFilter";
 import { FetchMyQuizzesParams } from "@/types/ParamsType";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import ROUTES from "@/data/routes";
 import { MySolvedQuizzesFilterType } from "@/types/FilterType";
 import { mySolvedQuizFilterAtom } from "@/store/filterAtom";
@@ -76,10 +76,14 @@ export default function SolvedQuiz() {
 
   const myQuizzes = myQuizzesData?.data;
 
+  const shouldRenderDataList = !isLoading && myQuizzes;
+  const shouldRenderPagination = useMemo(() => {
+    return (totalPagesLength ?? 0) > 0;
+  }, [totalPagesLength]);
+
   return (
-    !isLoading &&
-    myQuizzes && (
-      <div>
+    shouldRenderDataList && (
+      <>
         <QuizListLayout
           title="푼 퀴즈"
           quizzes={myQuizzes}
@@ -90,15 +94,15 @@ export default function SolvedQuiz() {
           filterCriteria={filterCriteria}
           filterOptions={filterOptions}
         />
-        {totalPagesLength && totalPagesLength > 0 && (
+        {shouldRenderPagination ? (
           <Pagination
             type="queryString"
             parentPage="my/solved-quiz"
             paginationState={paginationState}
             setPaginationState={setPaginationState}
           />
-        )}
-      </div>
+        ) : null}
+      </>
     )
   );
 }

--- a/src/pages/MyPage/composite/StudyGroupSolvedQuiz/studyGroupSolvedQuiz.tsx
+++ b/src/pages/MyPage/composite/StudyGroupSolvedQuiz/studyGroupSolvedQuiz.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import styles from "../StudyGroup/_study_group.module.scss";
 import {
   MyStudySolvedQuizzesFilterType,
@@ -119,6 +119,10 @@ export default function StudyGroupSolvedQuiz({ studyGroupId }: Props) {
     );
   };
 
+  const shouldRenderPagination = useMemo(() => {
+    return (totalPagesLength ?? 0) > 0;
+  }, [totalPagesLength]);
+
   return (
     <section className={styles.section}>
       <div className={styles["filter-container"]}>
@@ -146,7 +150,7 @@ export default function StudyGroupSolvedQuiz({ studyGroupId }: Props) {
       ) : (
         <NoDataSection title="아직 제출한 퀴즈가 없어요 😔" />
       )}
-      {totalPagesLength && isQuizzesExist ? (
+      {shouldRenderPagination ? (
         <Pagination
           type="state"
           paginationState={paginationState}

--- a/src/pages/MyPage/composite/StudyGroupUnsolvedQuiz/StudyGroupUnsolvedQuiz.tsx
+++ b/src/pages/MyPage/composite/StudyGroupUnsolvedQuiz/StudyGroupUnsolvedQuiz.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import styles from "../StudyGroup/_study_group.module.scss";
 import { parseQueryParams } from "@/utils/parseQueryParams";
 import { FetchStudyGroupsParams } from "@/types/ParamsType";
@@ -144,12 +144,16 @@ export default function StudyGroupUnsolvedQuiz({ studyGroupId }: Props) {
     );
   };
 
-  const isQuizzesExist = unsolvedQuizzes && unsolvedQuizzes.length > 0;
+  const shouldRenderDataList = unsolvedQuizzes && unsolvedQuizzes.length > 0;
+  const shouldRenderPagination = useMemo(() => {
+    return (totalPagesLength ?? 0) > 0;
+  }, [totalPagesLength]);
+
   return (
     <section>
       <div className={styles["filter-container"]}>
         <h3 className={styles.title}>풀어야 할 퀴즈</h3>
-        {isQuizzesExist ? (
+        {shouldRenderDataList ? (
           <ListFilter
             onOptionClick={handleOptionClick}
             sortFilter={filterCriteria}
@@ -157,7 +161,7 @@ export default function StudyGroupUnsolvedQuiz({ studyGroupId }: Props) {
           />
         ) : null}
       </div>
-      {isQuizzesExist ? (
+      {shouldRenderDataList ? (
         <ol className={styles["quiz-list"]}>
           {unsolvedQuizzes.map((quizData) => (
             <QuizItem
@@ -176,7 +180,7 @@ export default function StudyGroupUnsolvedQuiz({ studyGroupId }: Props) {
           onClick={() => handleAuthenticatedAction(handleGoToCreateQuiz)}
         />
       )}
-      {totalPagesLength && isQuizzesExist ? (
+      {shouldRenderPagination ? (
         <Pagination
           type="state"
           paginationState={paginationState}

--- a/src/styles/abstracts/_mixins.scss
+++ b/src/styles/abstracts/_mixins.scss
@@ -191,10 +191,13 @@
   height: 100%;
 }
 
-@mixin text-ellipsis {
-  white-space: nowrap;
+@mixin text-ellipsis($lines: 1) {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: $lines;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: normal;
 }
 
 @mixin questionExplanationImage {


### PR DESCRIPTION
- 퀴즈 목록 아이템 스타일 수정
  - `text-ellipsis` 믹스인을 적용하여 퀴즈 제목을 한줄로 고정
  - `text-ellipsis` 믹스인에 줄(line) 수를 지정할 수 있도록 수정
- 데이터 목록 로딩중일 경우 페이지네이션 컴포넌트 보이지 않도록 처리
  - 페이지네이션 컴포넌트가 목록 패칭이 완료된 경우 보이도록 수정
  - `useMemo`를 사용하여 페이지네이션 렌더링 최적화 함께 진행 (`totalPagesLength`가 바뀌는 경우에만 페이지네이션 컴포넌트를 리렌더링 하도록)
- LNB 컴포넌트의 왼쪽 화살표 클릭 시 책 목록 페이지로 이동하도록 수정
  - 클릭 시 navigate 경로 `ROUTES.ROOT` 에서 `ROUTES.BOOK_LIST`로 변경
- 마이페이지 퀴즈 아이템 책 사진 사이즈 조정
  - max-height 설정
- 퀴즈 문제 작성 가이드라인 어긋난 스타일 수정
  - 정확히 부모 요소에 `position: relative` 설정