### PR TITLE
Release 1.2.3

### DIFF
--- a/src/components/atom/Button/Button.tsx
+++ b/src/components/atom/Button/Button.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from "react";
 import styles from "./_button.module.scss";
-export type ButtonColorProps =
+export type ButtonColorType =
   | "primary"
   | "secondary"
   | "primary-border"
@@ -8,14 +8,14 @@ export type ButtonColorProps =
   | "white"
   | "transparent"
   | "red";
-interface ButtonProps {
+interface Props {
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   children?: ReactNode;
   id?: string;
   type?: "button" | "submit" | "reset";
   size?: "xsmall" | "small" | "medium" | "large" | "xlarge";
   mode?: "default" | "error";
-  color?: ButtonColorProps;
+  color?: ButtonColorType;
   disabled?: boolean;
   className?: string;
   value?: string;
@@ -27,7 +27,7 @@ interface ButtonProps {
   ableAnimation?: boolean;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+const Button = React.forwardRef<HTMLButtonElement, Props>(
   (
     {
       onClick = () => {},

--- a/src/components/atom/Checkbox/Checkbox.tsx
+++ b/src/components/atom/Checkbox/Checkbox.tsx
@@ -18,7 +18,7 @@ export type CheckboxStatusType =
   | "solving-correct" // '문제풀기'화면에서 채점시 정답
   | "solving-incorrect" // '문제풀기'화면에서 채점시 오답
   | "checkbox-black"; // 퀴즈 신고하기
-interface CheckBoxProps {
+interface Props {
   id: string;
   checked: boolean;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -47,7 +47,7 @@ export default function CheckBox({
   onFocus = () => {},
   onBlur = () => {},
   disabled,
-}: CheckBoxProps) {
+}: Props) {
   const optionMaxLength = 500;
   const [isTextAreaFocus, setIsTextAreaFocus] = useState(false);
 

--- a/src/components/atom/Dropdown/Dropdown.tsx
+++ b/src/components/atom/Dropdown/Dropdown.tsx
@@ -1,19 +1,19 @@
 import React from "react";
 import styles from "./_dropdown.module.scss";
 
-interface Option {
+interface OptionType {
   label: string;
   value: string;
 }
 
-interface DropdownProps {
-  options: Option[];
+interface Props {
+  options: OptionType[];
   onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   value: string;
   size?: "large" | "medium" | "small";
 }
 
-const Dropdown: React.FC<DropdownProps> = ({
+const Dropdown: React.FC<Props> = ({
   options,
   onChange,
   value,

--- a/src/components/atom/Input/Input.tsx
+++ b/src/components/atom/Input/Input.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styles from "./_input.module.scss";
 
-interface InputProps {
+interface Props {
   id: string;
   value: string | undefined;
   className?: string;
@@ -25,7 +25,7 @@ interface InputProps {
   maxLengthShow?: boolean;
 }
 
-const Input: React.FC<InputProps> = ({
+const Input: React.FC<Props> = ({
   id,
   value,
   onChange,

--- a/src/components/atom/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/atom/LoadingSpinner/LoadingSpinner.tsx
@@ -1,7 +1,7 @@
 import styles from "./_loading_spinner.module.scss";
 import loadingSpinner from "/public/assets/svg/quizBookSelectionForm/loading.gif";
 
-interface LoadingSpinnerProps {
+interface Props {
   width?: number;
   className?: string;
   pageCenter?: boolean;
@@ -10,7 +10,7 @@ export default function LoadingSpinner({
   width,
   className,
   pageCenter,
-}: LoadingSpinnerProps) {
+}: Props) {
   return (
     <img
       className={`${styles.container} ${className} ${pageCenter ? styles["page-center"] : ""}`}

--- a/src/components/atom/Modal/Modal.tsx
+++ b/src/components/atom/Modal/Modal.tsx
@@ -1,31 +1,31 @@
 import React from "react";
 import styles from "./_modal.module.scss";
 import { gray80 } from "@/styles/abstracts/colors";
-import Button, { ButtonColorProps } from "../Button/Button";
+import Button, { ButtonColorType } from "../Button/Button";
 import { XMedium } from "@/svg/XMedium";
 
-export interface ModalContentProps {
+export interface ModalContentType {
   title: string;
   content: JSX.Element;
 }
 
-export interface BottomButtonProps {
-  color: ButtonColorProps;
+export interface BottomButtonType {
+  color: ButtonColorType;
   text: string;
   onClick: () => void;
   disabled?: boolean;
 }
 
-interface ModalProps {
+interface Props {
   width?: number;
   title?: string;
-  contents?: ModalContentProps[];
-  bottomButtons?: BottomButtonProps[];
+  contents?: ModalContentType[];
+  bottomButtons?: BottomButtonType[];
   closeModal: () => void;
   showHeaderCloseButton?: boolean;
 }
 
-const Modal: React.FC<ModalProps> = ({
+const Modal: React.FC<Props> = ({
   width = 560,
   title,
   contents,

--- a/src/components/atom/PasswordMatchCheckMessage/PasswordMatchCheckMessage.tsx
+++ b/src/components/atom/PasswordMatchCheckMessage/PasswordMatchCheckMessage.tsx
@@ -4,11 +4,13 @@ import { systemSuccess } from "@/styles/abstracts/colors";
 import { systemDanger } from "@/styles/abstracts/colors";
 import styles from "./_password_match_check_message.module.scss";
 
+interface Props {
+  isPasswordMatched: boolean;
+}
+
 export default function PasswordMatchCheckMessage({
   isPasswordMatched,
-}: {
-  isPasswordMatched: boolean;
-}) {
+}: Props) {
   return (
     <span className={styles["password-check-message-container"]}>
       <p>{isPasswordMatched ? "비밀번호 일치" : "비밀번호 불일치"}</p>

--- a/src/components/atom/PasswordValidationMessage/PasswordValidationMessage.tsx
+++ b/src/components/atom/PasswordValidationMessage/PasswordValidationMessage.tsx
@@ -2,13 +2,16 @@ import styles from "./_password_validation_message.module.scss";
 import { gray40, systemSuccess } from "@/styles/abstracts/colors";
 import { Check } from "@/svg/Check";
 // TODO: passwordset 공통코드 제거
-export default function PasswordValidationMessage({
-  passwordValidations,
-}: {
+
+interface Props {
   passwordValidations: {
     [key: string]: boolean;
   };
-}) {
+}
+
+export default function PasswordValidationMessage({
+  passwordValidations,
+}: Props) {
   return (
     <div className={styles["password-message-container"]}>
       {Object.entries(passwordValidations).map(([key, isValid]) => (

--- a/src/components/atom/RadioOption/RadioOption.tsx
+++ b/src/components/atom/RadioOption/RadioOption.tsx
@@ -20,7 +20,7 @@ export type OptionStatusType =
   | "option-selected" // '문제풀기'화면에서 선택된 경우
   | "solving-correct" // '문제풀기'화면에서 채점시 정답
   | "solving-incorrect"; // '문제풀기'화면에서 채점시 오답
-interface RadioOptionProps {
+interface Props {
   option: RadioOptionType;
   type?: OptionStatusType;
   checked: boolean;
@@ -39,7 +39,7 @@ interface RadioOptionProps {
   showDeleteBtn?: boolean;
 }
 
-const RadioOption: React.FC<RadioOptionProps> = ({
+const RadioOption: React.FC<Props> = ({
   option,
   type = "option-writing",
   checked,

--- a/src/components/atom/RadioOption/RadioOption.tsx
+++ b/src/components/atom/RadioOption/RadioOption.tsx
@@ -159,6 +159,7 @@ const RadioOption: React.FC<Props> = ({
               disabled={
                 isFirstVisit && !isEditMode && currentQuizGuideStep == 2
               }
+              className={styles["guide-option-delete-button"]}
             />
           )}
       </label>

--- a/src/components/atom/RadioOption/_radio_option.module.scss
+++ b/src/components/atom/RadioOption/_radio_option.module.scss
@@ -178,3 +178,10 @@
   font-weight: $font-weight-regular;
   line-height: 150%;
 }
+
+.guide-option-delete-button {
+  &:disabled {
+    background-color: transparent;
+    border: none;
+  }
+}

--- a/src/components/atom/TermsModal/TermsModal.tsx
+++ b/src/components/atom/TermsModal/TermsModal.tsx
@@ -7,14 +7,14 @@ import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
-interface ModalProps {
+interface Props {
   title: string;
   content: string;
   closeModal: () => void;
   className?: string;
 }
 
-const TermsModal: React.FC<ModalProps> = ({
+const TermsModal: React.FC<Props> = ({
   title,
   content,
   closeModal,

--- a/src/components/atom/Textarea/Textarea.tsx
+++ b/src/components/atom/Textarea/Textarea.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent } from "react";
 import styles from "./_textarea.module.scss";
 
-interface TextareaProps {
+interface Props {
   id: string;
   value: string;
   onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
@@ -26,7 +26,7 @@ interface TextareaProps {
   type?: "option-label";
 }
 
-const Textarea: React.FC<TextareaProps> = ({
+const Textarea: React.FC<Props> = ({
   id,
   value,
   onChange,

--- a/src/components/atom/Toggle/Toggle.tsx
+++ b/src/components/atom/Toggle/Toggle.tsx
@@ -1,10 +1,10 @@
 import styles from "./_toggle.module.scss";
 
-interface ToggleProps {
+interface Props {
   onClick?: () => void;
   isActive?: boolean;
 }
-export default function Toggle({ onClick = () => {}, isActive }: ToggleProps) {
+export default function Toggle({ onClick = () => {}, isActive }: Props) {
   return (
     <div
       className={`${styles["toggle-container"]} ${

--- a/src/components/atom/Tooltip/Tooltip.tsx
+++ b/src/components/atom/Tooltip/Tooltip.tsx
@@ -1,13 +1,10 @@
 import styles from "./_tooltip.module.scss";
 
-interface TooltipProps {
+interface Props {
   label: string;
   className?: string;
 }
-export default function Tooltip({
-  label,
-  className: customClassName,
-}: TooltipProps) {
+export default function Tooltip({ label, className: customClassName }: Props) {
   const className = `${styles.container} ${customClassName ?? ""}`;
   return (
     <article className={className}>

--- a/src/components/composite/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/composite/Breadcrumb/Breadcrumb.tsx
@@ -3,15 +3,15 @@ import styles from "./_breadcrumb.module.scss";
 import { ArrowRight } from "@/svg/ArrowRight";
 import { gray90 } from "@/styles/abstracts/colors";
 import useNavigateWithParams from "@/hooks/useNavigateWithParams";
-import { ParentPage } from "@/types/PaginationType";
+import { ParentPageType } from "@/types/PaginationType";
 
-export interface ListItem {
+export interface ListItemType {
   id: number;
   name: string;
 }
 interface Props {
-  list: (ListItem | null)[];
-  parentPage: ParentPage;
+  list: (ListItemType | null)[];
+  parentPage: ParentPageType;
 }
 export default function Breadcrumb({ list, parentPage }: Props) {
   const { navigateWithParams } = useNavigateWithParams(parentPage);

--- a/src/components/composite/NoDataSection/NoDataSection.tsx
+++ b/src/components/composite/NoDataSection/NoDataSection.tsx
@@ -1,15 +1,13 @@
 import styles from "./_no-data-section.module.scss";
 import Button from "@/components/atom/Button/Button";
 
-export const NoDataSection = ({
-  title,
-  buttonName,
-  onClick,
-}: {
+interface Props {
   title: string;
   buttonName?: string;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-}) => {
+}
+
+export const NoDataSection = ({ title, buttonName, onClick }: Props) => {
   return (
     <div className={styles["no-data"]}>
       <p>{title}</p>

--- a/src/components/composite/Pagination/Pagination.tsx
+++ b/src/components/composite/Pagination/Pagination.tsx
@@ -7,12 +7,12 @@ import usePagination from "@/hooks/usePagination";
 import { useNavigate } from "react-router-dom";
 import { Dispatch, SetStateAction, useEffect } from "react";
 import { setQueryParam } from "@/utils/setQueryParam";
-import { PaginationType, ParentPage } from "@/types/PaginationType";
+import { PaginationType, ParentPageType } from "@/types/PaginationType";
 
 // TODO: 직관적으로 (변수명 등)
 interface QueryStringPaginationProps {
   type: "queryString";
-  parentPage: ParentPage;
+  parentPage: ParentPageType;
   itemId?: number;
   paginationState: PaginationType;
   setPaginationState: Dispatch<SetStateAction<PaginationType>>;

--- a/src/components/composite/QuizMenuList/QuizMenuList.tsx
+++ b/src/components/composite/QuizMenuList/QuizMenuList.tsx
@@ -6,13 +6,11 @@ import ROUTES from "@/data/routes";
 import useLoginAction from "@/hooks/useLoginAction";
 import toast from "react-hot-toast";
 import Button from "@/components/atom/Button/Button";
-interface HeaderQuizUtilListProps {
+interface Props {
   closeDropDownList: () => void;
 }
 
-export default function HeaderQuizUtilList({
-  closeDropDownList,
-}: HeaderQuizUtilListProps) {
+export default function HeaderQuizUtilList({ closeDropDownList }: Props) {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const { handleAuthenticatedAction } = useLoginAction(pathname);

--- a/src/components/composite/SocialAuthButton/SocialAuthButton.tsx
+++ b/src/components/composite/SocialAuthButton/SocialAuthButton.tsx
@@ -14,9 +14,11 @@ import {
 import { useAtom } from "jotai";
 import { authService } from "@/services/server/authService";
 
-const SocialAuthButton: React.FC<{
+interface Props {
   socialType: SocialLoginType;
-}> = ({ socialType }) => {
+}
+
+const SocialAuthButton: React.FC<Props> = ({ socialType }) => {
   const [, setIsEmailLoginPage] = useAtom(isEmailLoginPageAtom);
   const [socialLoginRedirectUrl] = useAtom(socialLoginRedirectUrlAtom);
 

--- a/src/components/layout/BaseLayout/BaseLayout.tsx
+++ b/src/components/layout/BaseLayout/BaseLayout.tsx
@@ -14,11 +14,11 @@ import mobileImage2 from "/public/assets/image/mobile/mobile-image2.png";
 import mobileImage3 from "/public/assets/image/mobile/mobile-image3.png";
 import arrow from "/public/assets/image/mobile/arrow.png";
 
-export default function BaseLayout({
-  showHeader = true,
-}: {
+interface Props {
   showHeader?: boolean;
-}) {
+}
+
+export default function BaseLayout({ showHeader = true }: Props) {
   const [currentUser, setCurrentUser] = useAtom(currentUserAtom);
   const [isUserLoading, setIsUserLoading] = useAtom(isUserLoadingAtom);
   const navigate = useNavigate();

--- a/src/components/layout/ImageLayer/ImageLayer.tsx
+++ b/src/components/layout/ImageLayer/ImageLayer.tsx
@@ -7,17 +7,19 @@ import leftArrow from "/public/assets/svg/imageLayer/leftArrow.svg";
 import rightArrow from "/public/assets/svg/imageLayer/rightArrow.svg";
 import { useEffect } from "react";
 
+interface Props {
+  image: AnswerImageType;
+  onLeftArrowClick: (e: React.MouseEvent) => void;
+  onRightArrowClick: (e: React.MouseEvent) => void;
+  onCloseLayer: () => void;
+}
+
 export default function ImageLayer({
   image,
   onLeftArrowClick,
   onRightArrowClick,
   onCloseLayer,
-}: {
-  image: AnswerImageType;
-  onLeftArrowClick: (e: React.MouseEvent) => void;
-  onRightArrowClick: (e: React.MouseEvent) => void;
-  onCloseLayer: () => void;
-}) {
+}: Props) {
   useEffect(() => {
     document.body.classList.add("no-scroll");
     return () => {

--- a/src/data/queryKeys.ts
+++ b/src/data/queryKeys.ts
@@ -1,30 +1,27 @@
 // TODO: id string | number 타입 통일하기
 import {
-  FetchBooksParams,
-  FetchMyQuizzesParams,
-  FetchQuizzesParams,
-  FetchReviewsParams,
-  FetchStudyGroupsParams,
-  SearchBooksParams,
+  BooksFetchType,
+  MyQuizzesFetchType,
+  QuizzesFetchType,
+  ReviewsFetchType,
+  StudyGroupsFetchType,
+  BooksSearchType,
 } from "@/types/ParamsType";
 
 export const bookKeys = {
   detail: (id: string | undefined) => ["bookDetailContent", id] as const,
   categories: () => ["bookCategories"] as const,
-  list: (param?: FetchBooksParams) => ["bookList", param] as const,
-  search: (params?: SearchBooksParams) => ["bookSearch", params] as const,
-  quizList: (params: FetchQuizzesParams) => ["bookQuizList", params] as const,
+  list: (param?: BooksFetchType) => ["bookList", param] as const,
+  search: (params?: BooksSearchType) => ["bookSearch", params] as const,
+  quizList: (params: QuizzesFetchType) => ["bookQuizList", params] as const,
 };
 
 export const studyGroupKeys = {
   detail: (id: number | undefined) => ["studyGroupDetail", id] as const,
-  list: (params?: FetchStudyGroupsParams) =>
-    ["studyGroupList", params] as const,
-  myUnsolvedQuizList: (
-    id: number | undefined,
-    params: FetchStudyGroupsParams,
-  ) => ["studyGroupMyUnsolvedQuizList", id, params] as const,
-  mySolvedQuizList: (id: number | undefined, params: FetchStudyGroupsParams) =>
+  list: (params?: StudyGroupsFetchType) => ["studyGroupList", params] as const,
+  myUnsolvedQuizList: (id: number | undefined, params: StudyGroupsFetchType) =>
+    ["studyGroupMyUnsolvedQuizList", id, params] as const,
+  mySolvedQuizList: (id: number | undefined, params: StudyGroupsFetchType) =>
     ["studyGroupMySolvedQuizList", id, params] as const,
   quizGradeResult: (studyGroupId: number, quizId: number) =>
     ["studyGroupQuizGradeResult", studyGroupId, quizId] as const,
@@ -42,8 +39,8 @@ export const userKeys = {
 };
 
 export const quizKeys = {
-  myQuiz: (params: FetchMyQuizzesParams) => ["myQuiz", params] as const,
-  solvedQuiz: (params: FetchMyQuizzesParams) => ["solvedQuiz", params] as const,
+  myQuiz: (params: MyQuizzesFetchType) => ["myQuiz", params] as const,
+  solvedQuiz: (params: MyQuizzesFetchType) => ["solvedQuiz", params] as const,
   detail: (id: string | undefined) => ["quizDetail", id] as const,
   prevDetail: (id: string | undefined) => ["prevDetail", id] as const,
   explanation: (id: string | undefined) => ["quizExplanation", id] as const,
@@ -57,6 +54,6 @@ export const quizKeys = {
 
 export const reviewKeys = {
   totalScore: (id: number | undefined) => ["reviewTotalScore", id] as const,
-  list: (param?: FetchReviewsParams) => ["reviewList", param] as const,
+  list: (param?: ReviewsFetchType) => ["reviewList", param] as const,
   myReview: (id: number | undefined) => ["myReview", id] as const,
 };

--- a/src/data/routes.ts
+++ b/src/data/routes.ts
@@ -1,7 +1,4 @@
-import {
-  QuizResultRouteParams,
-  QuizReviewRouteParams,
-} from "@/types/ParamsType";
+import { QuizResultRouteType, QuizReviewRouteType } from "@/types/ParamsType";
 
 const ROUTES = {
   ROOT: "/",
@@ -40,12 +37,12 @@ const ROUTES = {
   QUIZ: "/quiz",
   SOLVING_QUIZ: (quizId?: number) => `/quiz/play/${quizId ?? ":quizId"}`,
 
-  QUIZ_REVIEW: (param?: QuizReviewRouteParams) =>
+  QUIZ_REVIEW: (param?: QuizReviewRouteType) =>
     `/quiz/review/${param?.quizId ?? ":quizId"}/${
       param?.solvingQuizId ?? ":solvingQuizId"
     }/${param?.quizTitle ?? ":quizTitle"}`,
 
-  QUIZ_RESULT: (param?: QuizResultRouteParams) =>
+  QUIZ_RESULT: (param?: QuizResultRouteType) =>
     `/quiz/result/${param?.quizId ?? ":quizId"}/${
       param?.solvingQuizId ?? ":solvingQuizId"
     }/${param?.quizTitle ?? ":quizTitle"}/${

--- a/src/hooks/mutate/useUpdateUser.ts
+++ b/src/hooks/mutate/useUpdateUser.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { authService } from "@/services/server/authService";
 import { ErrorType } from "@/types/ErrorType";
 import toast from "react-hot-toast";
-import { UpdateUserParams } from "@/types/ParamsType";
+import { UserUpdateType } from "@/types/ParamsType";
 import { useAtom } from "jotai";
 import { currentUserAtom } from "@/store/userAtom";
 import { queryClient } from "@/services/server/queryClient";
@@ -13,7 +13,7 @@ const useUpdateUser = () => {
   const { mutate: updateUser } = useMutation<
     { toastMessage: string; needToInvalidateQuery?: boolean },
     ErrorType,
-    { user: UpdateUserParams; toastMessage: string; needToReload?: boolean }
+    { user: UserUpdateType; toastMessage: string; needToReload?: boolean }
   >({
     mutationFn: async ({ user, toastMessage, needToReload }) => {
       await authService.updateUser(user);

--- a/src/hooks/useIsQuizStepEnabled.ts
+++ b/src/hooks/useIsQuizStepEnabled.ts
@@ -1,9 +1,6 @@
 import { QUIZ_CREATION_STEP } from "@/data/constants";
-import { QuizCreationType } from "@/types/QuizType";
-export const useIsQuizStepEnabled = (
-  order: number,
-  quizInfo: QuizCreationType,
-) => {
+import { QuizFormType } from "@/types/QuizType";
+export const useIsQuizStepEnabled = (order: number, quizInfo: QuizFormType) => {
   switch (order) {
     case QUIZ_CREATION_STEP.STUDY_GROUP_SELECT:
       return true;

--- a/src/hooks/useNavigateWithParams.ts
+++ b/src/hooks/useNavigateWithParams.ts
@@ -8,8 +8,8 @@ import {
   QuizzesFilterType,
   ReviewsFilterType,
 } from "@/types/FilterType";
-import { ParentPage } from "@/types/PaginationType";
-import { FetchBooksKeyType } from "@/types/ParamsType";
+import { ParentPageType } from "@/types/PaginationType";
+import { BooksFetchKeyType } from "@/types/ParamsType";
 import { useAtom } from "jotai";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
@@ -17,7 +17,7 @@ import { useNavigate } from "react-router-dom";
 // 지정된 필터, 페이지, 카테고리 등의 파라미터를 URL에 반영하고
 // 필요 시 제외 파라미터를 처리하는 등
 // 페이지 이동과 상태 업데이트를 동시에 수행
-const useNavigateWithParams = (parentPage: ParentPage) => {
+const useNavigateWithParams = (parentPage: ParentPageType) => {
   const navigate = useNavigate();
   const [, setPaginationState] = useAtom(paginationAtom);
   const [prevPaginationState] = useAtom(prevPaginationStateAtom);
@@ -68,8 +68,8 @@ const useNavigateWithParams = (parentPage: ParentPage) => {
     title?: string;
     page?: number;
     category?: string;
-    parentPage: ParentPage;
-    excludeParams?: FetchBooksKeyType[];
+    parentPage: ParentPageType;
+    excludeParams?: BooksFetchKeyType[];
     itemId?: number;
   }) => {
     const queryParams = new URLSearchParams(window.location.search);

--- a/src/hooks/useQuestionTemplate.ts
+++ b/src/hooks/useQuestionTemplate.ts
@@ -1,6 +1,6 @@
 import useUpdateQuizCreationInfo from "./useUpdateQuizCreationInfo";
-import { AnswerType, QuizQuestionType } from "@/types/QuizType";
-import { CheckBoxOption } from "@/types/CheckBoxTypes";
+import { AnswerType, QuizQuestionFormType } from "@/types/QuizType";
+import { CheckBoxOptionType } from "@/types/CheckBoxTypes";
 import { RadioOptionType } from "@/types/RadioTypes";
 import { useState } from "react";
 import { BOOK_QUIZ_OPTION_MAX_LENGTH } from "@/data/constants";
@@ -12,15 +12,15 @@ export const useQuestionTemplate = (
   const { quizCreationInfo, updateQuizCreationInfo } =
     useUpdateQuizCreationInfo();
 
-  const getQuestion = (): QuizQuestionType =>
+  const getQuestion = (): QuizQuestionFormType =>
     quizCreationInfo.questions?.find(
       (question) => question.id!.toString() === questionFormId,
-    ) as QuizQuestionType;
+    ) as QuizQuestionFormType;
 
   const setInitialOptions = (
     questionFormType: AnswerType,
-  ): (CheckBoxOption | RadioOptionType)[] => {
-    const question: QuizQuestionType = getQuestion();
+  ): (CheckBoxOptionType | RadioOptionType)[] => {
+    const question: QuizQuestionFormType = getQuestion();
 
     const initialOptions =
       question?.selectOptions.map((option) => ({
@@ -30,17 +30,17 @@ export const useQuestionTemplate = (
       })) ?? [];
 
     return questionFormType === "MULTIPLE_CHOICE_MULTIPLE_ANSWER"
-      ? (initialOptions as CheckBoxOption[])
+      ? (initialOptions as CheckBoxOptionType[])
       : (initialOptions as RadioOptionType[]);
   };
 
-  const [options, setOptions] = useState<(RadioOptionType | CheckBoxOption)[]>(
-    setInitialOptions(questionFormType),
-  );
+  const [options, setOptions] = useState<
+    (RadioOptionType | CheckBoxOptionType)[]
+  >(setInitialOptions(questionFormType));
 
   const deleteOption = (optionId: number) => {
     setOptions(options.filter((option) => option.id !== optionId));
-    const updatedQuestions: QuizQuestionType[] =
+    const updatedQuestions: QuizQuestionFormType[] =
       quizCreationInfo.questions?.map((question) => {
         const filteredSelectOptions = question.selectOptions.filter(
           (option) => option.id !== optionId,

--- a/src/hooks/useUpdateQuizCreationInfo.ts
+++ b/src/hooks/useUpdateQuizCreationInfo.ts
@@ -1,12 +1,12 @@
 import { useAtom } from "jotai";
 import { quizCreationInfoAtom } from "@/store/quizAtom";
-import { QuizCreationType } from "@/types/QuizType";
+import { QuizFormType } from "@/types/QuizType";
 
 const useUpdateQuizCreationInfo = () => {
   const [quizCreationInfo, setQuizCreationInfo] =
-    useAtom<QuizCreationType>(quizCreationInfoAtom);
+    useAtom<QuizFormType>(quizCreationInfoAtom);
 
-  const updateQuizCreationInfo = <T extends keyof QuizCreationType, V>(
+  const updateQuizCreationInfo = <T extends keyof QuizFormType, V>(
     field: T,
     value: V,
   ) => {

--- a/src/hooks/useValidateQuizForm.ts
+++ b/src/hooks/useValidateQuizForm.ts
@@ -1,18 +1,18 @@
-import { QuizQuestionType } from "@/types/QuizType";
-import { SelectOptionType } from "@/types/QuizType";
+import { QuizQuestionFormType } from "@/types/QuizType";
+import { SelectOptionFormType } from "@/types/QuizType";
 import { SetStateAction } from "jotai";
 export const useValidateQuizForm = (
-  questions: QuizQuestionType[],
+  questions: QuizQuestionFormType[],
   notValidCallBack: (errorTitle: string, questionId: number) => void,
   setInvalidQuestionFormId?: (
     value: SetStateAction<number | undefined>,
   ) => void,
 ) => {
-  const hasDuplicate = (arr: SelectOptionType[]) => {
+  const hasDuplicate = (arr: SelectOptionFormType[]) => {
     const options: string[] = arr.map(({ option }) => option);
     return new Set(options).size !== options.length;
   };
-  const isEmpty = (arr: SelectOptionType[]): boolean => {
+  const isEmpty = (arr: SelectOptionFormType[]): boolean => {
     return arr.some(({ option }) => option.length === 0);
   };
   for (const question of questions ?? []) {
@@ -28,7 +28,7 @@ export const useValidateQuizForm = (
       return false;
     }
 
-    const selectOptions: SelectOptionType[] = question.selectOptions;
+    const selectOptions: SelectOptionFormType[] = question.selectOptions;
     // 작성하지 않은 옵션이 있습니다.
     if (isEmpty(selectOptions)) {
       notValidCallBack("작성하지 않은 옵션이 있습니다.", question.id);

--- a/src/pages/BookDetail/composite/BookDetailSection/BookDetailSection.tsx
+++ b/src/pages/BookDetail/composite/BookDetailSection/BookDetailSection.tsx
@@ -5,14 +5,14 @@ import { useAtom } from "jotai";
 import { quizzesLengthAtom } from "@/store/quizAtom.ts";
 import useLoginAction from "@/hooks/useLoginAction";
 import { useLocation } from "react-router-dom";
-
+interface Props {
+  bookDetailContent: BookDetailType;
+  onGoToMakeQuiz: () => void;
+}
 export default function BookDetailContent({
   bookDetailContent,
   onGoToMakeQuiz,
-}: {
-  bookDetailContent: BookDetailType;
-  onGoToMakeQuiz: () => void;
-}) {
+}: Props) {
   const [quizLength] = useAtom(quizzesLengthAtom);
   const { pathname } = useLocation();
 

--- a/src/pages/BookDetail/composite/QuizItem/_quiz_item.module.scss
+++ b/src/pages/BookDetail/composite/QuizItem/_quiz_item.module.scss
@@ -10,6 +10,7 @@
   border-radius: 8px;
   gap: 40px;
   cursor: pointer;
+  min-width: 0;
 }
 .content {
   display: flex;
@@ -41,6 +42,7 @@
 }
 
 .quiz-title {
+  @include text-ellipsis;
   font-size: $font-size-xlarge;
   font-weight: $font-weight-bold;
 }

--- a/src/pages/BookDetail/composite/QuizListSection/QuizListSection.tsx
+++ b/src/pages/BookDetail/composite/QuizListSection/QuizListSection.tsx
@@ -12,7 +12,7 @@ import useNavigateWithParams from "@/hooks/useNavigateWithParams.ts";
 import ListFilter from "@/components/composite/ListFilter/ListFilter.tsx";
 import { NoDataSection } from "@/components/composite/NoDataSection/NoDataSection.tsx";
 import { paginationAtom } from "@/store/paginationAtom.ts";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import ROUTES from "@/data/routes.ts";
 import { quizzesLengthAtom } from "@/store/quizAtom.ts";
 import useLoginAction from "@/hooks/useLoginAction.ts";
@@ -100,6 +100,9 @@ export default function QuizListSection({ bookId }: Props) {
   const handleGoToQuizDetail = (quizId: number) => {
     handleAuthenticatedAction(() => navigate(ROUTES.QUIZ_DETAIL(quizId)));
   };
+  const shouldRenderPagination = useMemo(() => {
+    return (totalPagesLength ?? 0) > 0;
+  }, [totalPagesLength]);
 
   if (isLoading) {
     return <LoadingSpinner width={40} pageCenter />;
@@ -130,7 +133,7 @@ export default function QuizListSection({ bookId }: Props) {
             />
           ))}
       </div>
-      {totalPagesLength && totalPagesLength > 0 && (
+      {shouldRenderPagination ? (
         <Pagination
           type="queryString"
           parentPage="book"
@@ -138,7 +141,7 @@ export default function QuizListSection({ bookId }: Props) {
           paginationState={paginationState}
           setPaginationState={setPaginationState}
         />
-      )}
+      ) : null}
     </section>
   );
 }

--- a/src/pages/BookDetail/composite/QuizListSection/QuizListSection.tsx
+++ b/src/pages/BookDetail/composite/QuizListSection/QuizListSection.tsx
@@ -17,11 +17,13 @@ import ROUTES from "@/data/routes.ts";
 import { quizzesLengthAtom } from "@/store/quizAtom.ts";
 import useLoginAction from "@/hooks/useLoginAction.ts";
 import { quizzesFilterAtom } from "@/store/filterAtom.ts";
-import { FetchQuizzesParams } from "@/types/ParamsType.ts";
+import { QuizzesFetchType } from "@/types/ParamsType.ts";
 import { QuizzesFilterType } from "@/types/FilterType.ts";
 import LoadingSpinner from "@/components/atom/LoadingSpinner/LoadingSpinner.tsx";
-
-export default function QuizListSection({ bookId }: { bookId: string }) {
+interface Props {
+  bookId: string;
+}
+export default function QuizListSection({ bookId }: Props) {
   const { search, pathname } = useLocation();
   const queryParams = new URLSearchParams(search);
   const navigate = useNavigate();
@@ -40,7 +42,7 @@ export default function QuizListSection({ bookId }: { bookId: string }) {
   const page = queryParams.get("page");
   const pageSize = "6";
 
-  const params: FetchQuizzesParams = {
+  const params: QuizzesFetchType = {
     page: page ?? "1",
     bookId: bookId,
     sort: sort ?? "CREATED_AT",

--- a/src/pages/BookList/composite/Lnb/Lnb.tsx
+++ b/src/pages/BookList/composite/Lnb/Lnb.tsx
@@ -2,7 +2,7 @@
 import styles from "./_lnb.module.scss";
 import Button from "@/components/atom/Button/Button";
 import { useNavigate } from "react-router-dom";
-import { BookCategory } from "@/types/GNBCategoryType";
+import { BookCategoryType } from "@/types/GNBCategoryType";
 import { findTopParentCategoryInfo } from "@/utils/findCategoryInfo";
 import { ArrowLeft } from "@/svg/ArrowLeft";
 import { gray90 } from "@/styles/abstracts/colors";
@@ -12,13 +12,13 @@ import { prevPaginationStateAtom } from "@/store/paginationAtom";
 import { useAtom } from "jotai";
 
 // Book Category GNB
-export default function LNB({
-  categories,
-  categoryId,
-}: {
-  categories: BookCategory[];
+
+interface Props {
+  categories: BookCategoryType[];
   categoryId?: number;
-}) {
+}
+
+export default function LNB({ categories, categoryId }: Props) {
   const navigate = useNavigate();
   const { navigateWithParams } = useNavigateWithParams("books");
   const [, setPrevPaginationState] = useAtom(prevPaginationStateAtom);
@@ -77,39 +77,39 @@ export default function LNB({
         <ul className={styles["category-list"]}>
           {!categoryId
             ? categories?.map((category) => (
-              <li key={category.id} className={styles["category-item"]}>
-                <Button
-                  color="transparent"
-                  size="xsmall"
-                  // fullWidth
-                  value={category.id.toString()}
-                  className={styles["category-item-button"]}
-                  onClick={() => handleClick(category.id.toString())}
-                >
-                  {category.name}
-                </Button>
-              </li>
-            ))
-            : categories
-              .find((item) => item.id === parentCategoryInfo?.id)
-              ?.details?.map((categoryDetail) => (
-                <li
-                  key={categoryDetail.id}
-                  className={styles["category-detail-item"]}
-                >
+                <li key={category.id} className={styles["category-item"]}>
                   <Button
-                    size="xsmall"
                     color="transparent"
-                    className={`${styles["category-detail-item-button"]} ${
-                      categoryId === categoryDetail.id ? styles.selected : ""
-                    }`}
-                    value={categoryDetail.id.toString()}
-                    onClick={() => handleClick(categoryDetail.id.toString())}
+                    size="xsmall"
+                    // fullWidth
+                    value={category.id.toString()}
+                    className={styles["category-item-button"]}
+                    onClick={() => handleClick(category.id.toString())}
                   >
-                    {categoryDetail.name}
+                    {category.name}
                   </Button>
                 </li>
-              ))}
+              ))
+            : categories
+                .find((item) => item.id === parentCategoryInfo?.id)
+                ?.details?.map((categoryDetail) => (
+                  <li
+                    key={categoryDetail.id}
+                    className={styles["category-detail-item"]}
+                  >
+                    <Button
+                      size="xsmall"
+                      color="transparent"
+                      className={`${styles["category-detail-item-button"]} ${
+                        categoryId === categoryDetail.id ? styles.selected : ""
+                      }`}
+                      value={categoryDetail.id.toString()}
+                      onClick={() => handleClick(categoryDetail.id.toString())}
+                    >
+                      {categoryDetail.name}
+                    </Button>
+                  </li>
+                ))}
         </ul>
       </div>
     </nav>

--- a/src/pages/BookList/composite/Lnb/Lnb.tsx
+++ b/src/pages/BookList/composite/Lnb/Lnb.tsx
@@ -59,7 +59,7 @@ export default function LNB({ categories, categoryId }: Props) {
                   />
                 }
                 iconOnly
-                onClick={() => navigate(ROUTES.ROOT)}
+                onClick={() => navigate(ROUTES.BOOK_LIST)}
               />
               <Button
                 size="xsmall"
@@ -81,7 +81,6 @@ export default function LNB({ categories, categoryId }: Props) {
                   <Button
                     color="transparent"
                     size="xsmall"
-                    // fullWidth
                     value={category.id.toString()}
                     className={styles["category-item-button"]}
                     onClick={() => handleClick(category.id.toString())}

--- a/src/pages/BookList/layout/BookListLayout/BookListLayout.tsx
+++ b/src/pages/BookList/layout/BookListLayout/BookListLayout.tsx
@@ -9,7 +9,7 @@ import {
   findTopParentCategoryInfo,
 } from "@/utils/findCategoryInfo";
 import Breadcrumb from "../../../../components/composite/Breadcrumb/Breadcrumb";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import Pagination from "@/components/composite/Pagination/Pagination";
 import { useAtom, useSetAtom } from "jotai";
 import {
@@ -93,10 +93,12 @@ export default function BookListLayout() {
 
   const books = booksData?.data;
   const endPageNumber = booksData?.endPageNumber;
+  const totalPagesLength = paginationState.totalPagesLength;
 
   // 마지막 페이지 번호 저장
   useEffect(() => {
-    if (endPageNumber && paginationState.totalPagesLength !== endPageNumber) {
+    if (endPageNumber && totalPagesLength !== endPageNumber) {
+      console.log(endPageNumber);
       setPaginationState((prev) => ({
         ...prev,
         totalPagesLength: endPageNumber,
@@ -128,6 +130,11 @@ export default function BookListLayout() {
     ? findCurrentCategoryInfo(categories, Number(category))
     : null;
 
+  const shouldRenderDataList = !isBooksLoading || booksData;
+  const shouldRenderPagination = useMemo(() => {
+    return (totalPagesLength ?? 0) > 0;
+  }, [totalPagesLength]);
+
   return (
     <section className={styles.container}>
       {isCategoriesLoading || !categories ? null : (
@@ -153,8 +160,8 @@ export default function BookListLayout() {
             filterOptions={filterOptions}
           />
         </div>
-        {isBooksLoading || !booksData ? null : <Outlet context={{ books }} />}
-        {paginationState.totalPagesLength ? (
+        {shouldRenderDataList ? <Outlet context={{ books }} /> : null}
+        {shouldRenderPagination ? (
           <Pagination
             type="queryString"
             parentPage="books"

--- a/src/pages/BookList/layout/BookListLayout/BookListLayout.tsx
+++ b/src/pages/BookList/layout/BookListLayout/BookListLayout.tsx
@@ -24,7 +24,7 @@ import useNavigateWithParams from "@/hooks/useNavigateWithParams";
 import useFilter from "@/hooks/useFilter";
 import { BooksFilterType, BooksSortType } from "@/types/FilterType";
 import { parseQueryParams } from "@/utils/parseQueryParams";
-import { FetchBooksParams } from "@/types/ParamsType";
+import { BooksFetchType } from "@/types/ParamsType";
 import { bookFilterAtom, resetBooksFilter } from "@/store/filterAtom";
 
 // TODO: 외부 파일로 분리하기
@@ -74,7 +74,7 @@ export default function BookListLayout() {
   // 책 목록 가져오기
   const { data: booksData, isLoading: isBooksLoading } = useQuery({
     queryKey: bookKeys.list(
-      parseQueryParams<BooksSortType, FetchBooksParams>({
+      parseQueryParams<BooksSortType, BooksFetchType>({
         title,
         category,
         sort,

--- a/src/pages/CreateQuiz/composite/QuizBookSectionForm/BookListItem/BookListItem.tsx
+++ b/src/pages/CreateQuiz/composite/QuizBookSectionForm/BookListItem/BookListItem.tsx
@@ -1,35 +1,29 @@
 import { BookType } from "@/types/BookType";
 import { memo } from "react";
 import styles from "./_book_list_item.module.scss";
-
-export const BookListItem = memo(
-  ({
-    book,
-    isSelected,
-    onSelect,
-  }: {
-    book: BookType;
-    isSelected: boolean;
-    onSelect: (book: BookType) => void;
-  }) => {
-    const handleSelect = () => {
-      if (isSelected) return;
-      onSelect(book);
-    };
-    return (
-      <li
-        key={book.id}
-        className={styles["booklist-item"]}
-        onClick={handleSelect}
-      >
-        <img src={book.imageUrl} alt={book.title} width={66} height={88} />
-        <div className={styles["info-container"]}>
-          <span className={styles.title}>{book.title}</span>
-          <span className={styles.author}>
-            {book.authors} ({book.publisher})
-          </span>
-        </div>
-      </li>
-    );
-  },
-);
+interface Props {
+  book: BookType;
+  isSelected: boolean;
+  onSelect: (book: BookType) => void;
+}
+export const BookListItem = memo(({ book, isSelected, onSelect }: Props) => {
+  const handleSelect = () => {
+    if (isSelected) return;
+    onSelect(book);
+  };
+  return (
+    <li
+      key={book.id}
+      className={styles["booklist-item"]}
+      onClick={handleSelect}
+    >
+      <img src={book.imageUrl} alt={book.title} width={66} height={88} />
+      <div className={styles["info-container"]}>
+        <span className={styles.title}>{book.title}</span>
+        <span className={styles.author}>
+          {book.authors} ({book.publisher})
+        </span>
+      </div>
+    </li>
+  );
+});

--- a/src/pages/CreateQuiz/composite/QuizSettingStudyGroupForm/QuizSettingStudyGroupForm.tsx
+++ b/src/pages/CreateQuiz/composite/QuizSettingStudyGroupForm/QuizSettingStudyGroupForm.tsx
@@ -4,7 +4,7 @@ import useModal from "@/hooks/useModal.ts";
 import useInput from "@/hooks/useInput.ts";
 import Button from "@/components/atom/Button/Button";
 import { primary } from "@/styles/abstracts/colors.ts";
-import Modal, { ModalContentProps } from "@/components/atom/Modal/Modal";
+import Modal, { ModalContentType } from "@/components/atom/Modal/Modal";
 import Input from "@/components/atom/Input/Input";
 import { QuizPlus } from "@/svg/QuizPlus";
 import { XMedium } from "@/svg/XMedium";
@@ -141,7 +141,7 @@ export default function QuizSettingStudyGroupForm() {
     //   studyGroup === selectedStudyGroup ? null : studyGroup
     // );
   };
-  const getContents = (): ModalContentProps[] => {
+  const getContents = (): ModalContentType[] => {
     const contents = [
       {
         title: "새로운 스터디 그룹 이름",
@@ -211,7 +211,7 @@ export default function QuizSettingStudyGroupForm() {
         : null,
     ];
     return contents.filter(
-      (content): content is ModalContentProps => content !== null,
+      (content): content is ModalContentType => content !== null,
     );
   };
 

--- a/src/pages/CreateQuiz/composite/QuizSettingsForm/QuizSettingContainer/QuizSettingContainer.tsx
+++ b/src/pages/CreateQuiz/composite/QuizSettingsForm/QuizSettingContainer/QuizSettingContainer.tsx
@@ -5,15 +5,17 @@ import { QuizSettingOptionType, QuizSettingType } from "@/types/QuizType";
 import { useEffect, useState } from "react";
 import { ArrowDown } from "@/svg/ArrowDown";
 
+interface Props {
+  quizSetting: QuizSettingType;
+  onOptionSelect: (name: string, label: string) => void;
+  selectedOptionLabel: string | null;
+}
+
 export const QuizSettingContainer = ({
   quizSetting,
   onOptionSelect,
   selectedOptionLabel,
-}: {
-  quizSetting: QuizSettingType;
-  onOptionSelect: (name: string, label: string) => void;
-  selectedOptionLabel: string | null;
-}) => {
+}: Props) => {
   const options = quizSetting.options;
 
   const [description, setDescription] = useState<string>("");

--- a/src/pages/CreateQuiz/composite/QuizSettingsForm/QuizSettingsForm.tsx
+++ b/src/pages/CreateQuiz/composite/QuizSettingsForm/QuizSettingsForm.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import useUpdateQuizCreationInfo from "@/hooks/useUpdateQuizCreationInfo";
 import {
-  QuizCreationType,
+  QuizFormType,
   QuizSettingType,
   scopeReverseTranslations,
   scopeTranslations,
@@ -30,7 +30,7 @@ export default function QuizSettingsForm() {
       if (value) {
         const scopeKey = key === "view-access" ? "viewScope" : "editScope";
         updateQuizCreationInfo(
-          scopeKey as keyof QuizCreationType,
+          scopeKey as keyof QuizFormType,
           scopeTranslations[value],
         );
       }

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/CheckBoxQuestionTemplate.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/CheckBoxQuestionTemplate.tsx
@@ -1,18 +1,19 @@
 import { FC, useState } from "react";
 import styles from "./_question_form.module.scss";
-import { QuizQuestionType } from "@/types/QuizType";
+import { QuizQuestionFormType } from "@/types/QuizType";
 import useUpdateQuizCreationInfo from "@/hooks/useUpdateQuizCreationInfo";
 import { useQuestionTemplate } from "@/hooks/useQuestionTemplate";
 import SelectOption from "./SelectOption";
-import { SelectOptionType } from "@/types/QuizType";
+import { SelectOptionFormType } from "@/types/QuizType";
 import { BOOK_QUIZ_OPTION_MAX_LENGTH } from "@/data/constants";
 import Button from "@/components/atom/Button/Button";
 import { QuizPlus } from "@/svg/QuizPlus";
 import { gray60 } from "@/styles/abstracts/colors";
 
-export const CheckBoxQuestionTemplate: FC<{
+interface Props {
   questionFormId?: string;
-}> = ({ questionFormId }) => {
+}
+export const CheckBoxQuestionTemplate: FC<Props> = ({ questionFormId }) => {
   const { quizCreationInfo, updateQuizCreationInfo } =
     useUpdateQuizCreationInfo();
   const {
@@ -25,7 +26,7 @@ export const CheckBoxQuestionTemplate: FC<{
   const currentOptionLength = options.length;
 
   const setInitialAnswer = (): { [key: string]: boolean } => {
-    const question: QuizQuestionType = getQuestion();
+    const question: QuizQuestionFormType = getQuestion();
     const initCheckedOptions: { [key: string]: boolean } = {};
 
     question.selectOptions.forEach(({ id, value }) => {
@@ -41,14 +42,14 @@ export const CheckBoxQuestionTemplate: FC<{
   const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { id, checked } = event.target;
 
-    const currentQuestion: QuizQuestionType | undefined =
+    const currentQuestion: QuizQuestionFormType | undefined =
       quizCreationInfo.questions?.find(
         (question) => question.id!.toString() === questionFormId!,
       );
     if (!currentQuestion) {
       return;
     }
-    const targetSelectOption: SelectOptionType =
+    const targetSelectOption: SelectOptionFormType =
       currentQuestion.selectOptions.find(
         (option) => id === option.id.toString(),
       )!;

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/MultipleChoiceQuestionTemplate.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/MultipleChoiceQuestionTemplate.tsx
@@ -1,7 +1,7 @@
 import styles from "./_question_form.module.scss";
 import { FC, useEffect, useState } from "react";
 import useRadioGroup from "@/hooks/useRadioGroup.ts";
-import { QuizQuestionType, SelectOptionType } from "@/types/QuizType";
+import { QuizQuestionFormType, SelectOptionFormType } from "@/types/QuizType";
 import useUpdateQuizCreationInfo from "@/hooks/useUpdateQuizCreationInfo";
 import { useQuestionTemplate } from "@/hooks/useQuestionTemplate";
 import SelectOption from "./SelectOption";
@@ -12,10 +12,12 @@ import QuizWriteGuideBubble from "../QuizWriteGuideBubble/QuizWriteGuideBubble";
 import Button from "@/components/atom/Button/Button";
 import { QuizPlus } from "@/svg/QuizPlus";
 import { gray60 } from "@/styles/abstracts/colors";
-
-export const MultipleChoiceQuestionTemplate: FC<{
+interface Props {
   questionFormId?: string;
-}> = ({ questionFormId }) => {
+}
+export const MultipleChoiceQuestionTemplate: FC<Props> = ({
+  questionFormId,
+}) => {
   const { quizCreationInfo, updateQuizCreationInfo } =
     useUpdateQuizCreationInfo();
   const [currentQuizGuideStep] = useAtom(quizGuideStepAtom);
@@ -55,7 +57,7 @@ export const MultipleChoiceQuestionTemplate: FC<{
     const { id } = event.target;
     onRadioGroupChange(event);
 
-    const currentQuestion: QuizQuestionType | undefined =
+    const currentQuestion: QuizQuestionFormType | undefined =
       quizCreationInfo.questions?.find(
         (question) => question.id!.toString() === questionFormId!,
       );
@@ -63,14 +65,14 @@ export const MultipleChoiceQuestionTemplate: FC<{
     if (!currentQuestion) {
       return;
     }
-    const targetSelectOption: SelectOptionType =
+    const targetSelectOption: SelectOptionFormType =
       currentQuestion.selectOptions.find(
         (option) => id === option.id.toString(),
       )!; // 선택된 옵션의 id값으로 전역 데이터에서 해당하는 옵션 데이터 매칭
 
     const currentAnswer: string = targetSelectOption.answerIndex.toString(); // 그 옵션의 정답 값을 현재 정답으로 저장
 
-    const updatedQuestions: QuizQuestionType[] = // 전뎍 데이터 업데이트
+    const updatedQuestions: QuizQuestionFormType[] = // 전뎍 데이터 업데이트
       quizCreationInfo.questions!.map((question) =>
         question.id!.toString() === questionFormId
           ? { ...question, answers: [currentAnswer] }

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/MultipleChoiceQuestionTemplate.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/MultipleChoiceQuestionTemplate.tsx
@@ -97,7 +97,14 @@ export const MultipleChoiceQuestionTemplate: FC<Props> = ({
   }, [isFirstVisit, isEditMode, currentQuizGuideStep]);
 
   return (
-    <fieldset className={styles["question-options"]}>
+    <fieldset
+      className={styles["question-options"]}
+      style={
+        isFirstVisit && !isEditMode && currentQuizGuideStep == 2
+          ? { position: "relative", zIndex: 999 }
+          : {}
+      }
+    >
       <QuizWriteGuideBubble
         marginTop={-85}
         text={

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/OXQuestionTemplate.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/OXQuestionTemplate.tsx
@@ -5,10 +5,10 @@ import { FC } from "react";
 import styles from "./_question_form.module.scss";
 import useUpdateQuizCreationInfo from "@/hooks/useUpdateQuizCreationInfo";
 import { useQuestionTemplate } from "@/hooks/useQuestionTemplate";
-
-export const OXQuestionTemplate: FC<{
+interface Props {
   questionFormId?: string;
-}> = ({ questionFormId }) => {
+}
+export const OXQuestionTemplate: FC<Props> = ({ questionFormId }) => {
   const options: RadioOptionType[] = [
     {
       id: 1,

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionForm.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionForm.tsx
@@ -17,7 +17,7 @@ import { AnswerType, QuizQuestionFormType } from "@/types/QuizType";
 import QuestionTemplateTypeUtilButton from "./QuestionTemplateTypeUtilButton";
 import { OxQuiz } from "@/svg/QuizWriteForm/OXQuiz";
 import Button from "@/components/atom/Button/Button";
-import { gray60, gray90 } from "@/styles/abstracts/colors";
+import { gray90 } from "@/styles/abstracts/colors";
 import {
   errorMessageAtomFamily,
   invalidQuestionFormIdAtom,
@@ -390,7 +390,7 @@ export default function QuestionForm({
 
       <div className={styles["question-form-content"]}>
         <div className={styles["setting-container"]}>
-          <Button
+          {/* <Button
             icon={
               <ImageAdd
                 width={24}
@@ -401,7 +401,7 @@ export default function QuestionForm({
             }
             iconOnly
             className={styles["image-add-button"]}
-          />
+          /> */}
           <QuestionTemplateTypeUtilButton
             questionId={questionFormId}
             list={questionTemplates}

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionForm.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionForm.tsx
@@ -17,7 +17,7 @@ import { AnswerType, QuizQuestionFormType } from "@/types/QuizType";
 import QuestionTemplateTypeUtilButton from "./QuestionTemplateTypeUtilButton";
 import { OxQuiz } from "@/svg/QuizWriteForm/OXQuiz";
 import Button from "@/components/atom/Button/Button";
-import { gray90 } from "@/styles/abstracts/colors";
+import { gray60, gray90 } from "@/styles/abstracts/colors";
 import {
   errorMessageAtomFamily,
   invalidQuestionFormIdAtom,
@@ -390,7 +390,7 @@ export default function QuestionForm({
 
       <div className={styles["question-form-content"]}>
         <div className={styles["setting-container"]}>
-          {/* <Button
+          <Button
             icon={
               <ImageAdd
                 width={24}
@@ -401,7 +401,7 @@ export default function QuestionForm({
             }
             iconOnly
             className={styles["image-add-button"]}
-          /> */}
+          />
           <QuestionTemplateTypeUtilButton
             questionId={questionFormId}
             list={questionTemplates}

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionForm.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionForm.tsx
@@ -13,7 +13,7 @@ import useAutoResizeTextarea from "@/hooks/useAutoResizeTextArea";
 import { useAtom } from "jotai";
 import useUpdateQuizCreationInfo from "@/hooks/useUpdateQuizCreationInfo";
 import deleteIcon from "/assets/svg/quizWriteForm/deleteEllipse.svg";
-import { AnswerType, QuizQuestionType } from "@/types/QuizType";
+import { AnswerType, QuizQuestionFormType } from "@/types/QuizType";
 import QuestionTemplateTypeUtilButton from "./QuestionTemplateTypeUtilButton";
 import { OxQuiz } from "@/svg/QuizWriteForm/OXQuiz";
 import Button from "@/components/atom/Button/Button";
@@ -28,7 +28,7 @@ import QuizWriteGuideBubble from "../QuizWriteGuideBubble/QuizWriteGuideBubble";
 import { useValidateQuizForm } from "@/hooks/useValidateQuizForm";
 import ImageLayer from "@/components/layout/ImageLayer/ImageLayer";
 import useImageLayer from "@/hooks/useImageLayer";
-interface QuizWriteFormItemProps {
+interface Props {
   questionFormId: number;
   deleteQuestion: (id: number) => void;
   answerType: string;
@@ -78,7 +78,7 @@ export default function QuestionForm({
   deleteQuestion,
   answerType,
   onUpdateQuestionFormsWithAnswerType,
-}: QuizWriteFormItemProps) {
+}: Props) {
   const { quizCreationInfo, updateQuizCreationInfo } =
     useUpdateQuizCreationInfo();
   const [invalidQuestionFormId] = useAtom(invalidQuestionFormIdAtom);
@@ -151,7 +151,7 @@ export default function QuestionForm({
 
   const handleAnswerChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     onAnswerTextAreaChange(e);
-    const updatedQuestions: QuizQuestionType[] =
+    const updatedQuestions: QuizQuestionFormType[] =
       quizCreationInfo.questions?.map((question) =>
         question.id === questionFormId
           ? { ...question, answerExplanationContent: e.target.value }
@@ -187,7 +187,7 @@ export default function QuestionForm({
 
     setSelectedImages((prevImages) => prevImages.filter((_, i) => i !== index));
 
-    const updatedQuestions: QuizQuestionType[] =
+    const updatedQuestions: QuizQuestionFormType[] =
       quizCreationInfo.questions?.map((question) => {
         if (question.id === questionFormId!) {
           return {
@@ -230,7 +230,7 @@ export default function QuestionForm({
       setSelectedImages((prev) => [...prev, ...imgEls]);
       setImagePreviewEls((prev) => [...prev, ...imgEls]);
 
-      const updatedQuestions: QuizQuestionType[] =
+      const updatedQuestions: QuizQuestionFormType[] =
         quizCreationInfo.questions?.map((question) => {
           if (question.id === questionFormId!) {
             return {
@@ -250,7 +250,7 @@ export default function QuestionForm({
 
   const handleQuestionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     onQuestionChange(e);
-    const updatedQuestions: QuizQuestionType[] =
+    const updatedQuestions: QuizQuestionFormType[] =
       quizCreationInfo.questions?.map((question) =>
         question.id === questionFormId
           ? { ...question, content: e.target.value }

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionFormHeader.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionFormHeader.tsx
@@ -26,7 +26,11 @@ export default function QuestionFormHeader({
         data-allow-dnd="true"
         style={
           isFirstVisit && !isEditMode && currentQuizGuideStep == 3
-            ? { position: "relative", zIndex: 999 }
+            ? {
+                position: "relative",
+                zIndex: 999,
+                marginLeft: "-8px",
+              }
             : {}
         }
       >

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionTemplateTypeUtilButton.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionTemplateTypeUtilButton.tsx
@@ -6,16 +6,9 @@ import { gray60 } from "@/styles/abstracts/colors";
 import Button from "@/components/atom/Button/Button";
 import { QuestionTemplateType } from "@/types/QuestionTemplateType";
 import useUpdateQuizCreationInfo from "@/hooks/useUpdateQuizCreationInfo";
-import { AnswerType, QuizQuestionType } from "@/types/QuizType";
+import { AnswerType, QuizQuestionFormType } from "@/types/QuizType";
 
-//TODO: 변수명 직관적으로 변경 필요
-function QuestionTemplateTypeUtilButton({
-  questionId,
-  selectedOption,
-  setSelectedOption,
-  list,
-  onUpdateQuestionFormsWithAnswerType,
-}: {
+interface Props {
   questionId: number;
   list: QuestionTemplateType[];
   selectedOption: QuestionTemplateType;
@@ -24,14 +17,22 @@ function QuestionTemplateTypeUtilButton({
     questionId: number,
     newAnswerType: AnswerType,
   ) => void;
-}) {
+}
+//TODO: 변수명 직관적으로 변경 필요
+function QuestionTemplateTypeUtilButton({
+  questionId,
+  selectedOption,
+  setSelectedOption,
+  list,
+  onUpdateQuestionFormsWithAnswerType,
+}: Props) {
   const { quizCreationInfo, updateQuizCreationInfo } =
     useUpdateQuizCreationInfo();
 
   const onClick = (option: QuestionTemplateType) => {
     // 현재 질문이 ox이거나 ox로 바꾸려고 하는거면
     // 질문데이터 초기화
-    const updatedQuestions: QuizQuestionType[] =
+    const updatedQuestions: QuizQuestionFormType[] =
       quizCreationInfo.questions?.map((question) =>
         question.id === questionId
           ? question.answerType === "OX" || option.answerType === "OX"

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionTemplateUtilList.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/QuestionTemplateUtilList.tsx
@@ -2,10 +2,10 @@ import { gray60 } from "@/styles/abstracts/colors";
 import styles from "./_question_form.module.scss";
 import { QuestionTemplateType } from "@/types/QuestionTemplateType";
 
-type Props = {
+interface Props {
   onClick: (optionTitle: QuestionTemplateType) => void;
   list: QuestionTemplateType[];
-};
+}
 
 export default function QuestionTemplateUtilList({ list, onClick }: Props) {
   return (

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/QuizWriteForm.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/QuizWriteForm.tsx
@@ -3,14 +3,14 @@ import styles from "./_question_form.module.scss";
 import Button from "@/components/atom/Button/Button";
 import QuestionForm from "@/pages/CreateQuiz/composite/QuizWriteForm/QuestionForm";
 import { primary } from "@/styles/abstracts/colors.ts";
-import { QuizQuestionType } from "@/types/QuizType";
+import { QuizQuestionFormType } from "@/types/QuizType";
 import { QuestionFormType } from "@/types/QuizType";
 import useUpdateQuizCreationInfo from "@/hooks/useUpdateQuizCreationInfo";
 import { QuizPlus } from "@/svg/QuizPlus";
 import { AnswerType } from "@/types/QuizType";
 import React from "react";
 import { useAtom } from "jotai";
-import { QuizCreationType } from "@/types/QuizType";
+import { QuizFormType } from "@/types/QuizType";
 import { isFirstVisitAtom, quizCreationInfoAtom } from "@/store/quizAtom";
 import {
   closestCenter,
@@ -32,7 +32,6 @@ import { SortableItem } from "./dnd/SortableItem";
 import { Item } from "./dnd/Item";
 import { DndPermissionPointerSensor } from "./dnd/DndPermissionPointerSensor";
 
-//TODO: 아이콘 정리 필요
 const QuizWriteForm = React.memo(() => {
   {
     const { quizCreationInfo, updateQuizCreationInfo } =
@@ -172,12 +171,11 @@ const QuizWriteForm = React.memo(() => {
       setActiveFormId(null);
     };
 
-    const [, setQuizCreationInfo] =
-      useAtom<QuizCreationType>(quizCreationInfoAtom);
+    const [, setQuizCreationInfo] = useAtom<QuizFormType>(quizCreationInfoAtom);
 
     const defaultAnswerType: AnswerType = "MULTIPLE_CHOICE_SINGLE_ANSWER";
 
-    const createNewQuestion = (id: number): QuizQuestionType => ({
+    const createNewQuestion = (id: number): QuizQuestionFormType => ({
       id,
       content: "",
       selectOptions: [],
@@ -202,7 +200,7 @@ const QuizWriteForm = React.memo(() => {
     // 문제 추가 버튼 클릭
     const handleClickAddQuestionForm = () => {
       const id = Date.now();
-      const newQuestion: QuizQuestionType = createNewQuestion(id);
+      const newQuestion: QuizQuestionFormType = createNewQuestion(id);
       addQuestionForm(id);
       updateQuizCreationInfo("questions", [
         ...(quizCreationInfo.questions ?? []),

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/SelectOption.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/SelectOption.tsx
@@ -1,16 +1,16 @@
 import React, { useState } from "react";
-import { CheckBoxOption } from "@/types/CheckBoxTypes";
+import { CheckBoxOptionType } from "@/types/CheckBoxTypes";
 import styles from "./_question_form.module.scss";
 import CheckBox from "@/components/atom/Checkbox/Checkbox";
 import useUpdateQuizCreationInfo from "@/hooks/useUpdateQuizCreationInfo";
-import { AnswerType, QuizQuestionType } from "@/types/QuizType";
+import { AnswerType, QuizQuestionFormType } from "@/types/QuizType";
 import { RadioOptionType } from "@/types/RadioTypes";
 import RadioOption from "@/components/atom/RadioOption/RadioOption";
 import useAutoResizeTextarea from "@/hooks/useAutoResizeTextArea";
 import { isFirstVisitAtom, quizGuideStepAtom } from "@/store/quizAtom";
 import { useAtom } from "jotai";
-interface SelectOptionProps {
-  option: RadioOptionType | CheckBoxOption;
+interface Props {
+  option: RadioOptionType | CheckBoxOptionType;
   deleteOption: (id: number) => void;
   selectedValue: string | null | { [key: string]: boolean };
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -20,7 +20,7 @@ interface SelectOptionProps {
   checked?: boolean;
 }
 
-const SelectOption: React.FC<SelectOptionProps> = ({
+const SelectOption: React.FC<Props> = ({
   option,
   deleteOption,
   selectedValue,
@@ -43,7 +43,7 @@ const SelectOption: React.FC<SelectOptionProps> = ({
     onOptionChange(e);
     setText(option.id, e.target.value);
 
-    const updatedQuestions: QuizQuestionType[] =
+    const updatedQuestions: QuizQuestionFormType[] =
       quizCreationInfo.questions?.map((question) => {
         if (question.id!.toString() === questionFormId!) {
           return {

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/_question_form.module.scss
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/_question_form.module.scss
@@ -30,7 +30,7 @@
     background-color: $gray-00;
     width: 40px;
     height: 40px;
-    margin-left: -8px;
+    // margin-left: -8px;
 
     @include flex(row, center);
     border-radius: 50%;

--- a/src/pages/CreateQuiz/composite/QuizWriteForm/dnd/SortableItem.tsx
+++ b/src/pages/CreateQuiz/composite/QuizWriteForm/dnd/SortableItem.tsx
@@ -2,8 +2,10 @@ import { QuestionFormType } from "@/types/QuizType";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { cloneElement, CSSProperties, ReactElement } from "react";
-
-export const SortableItem = ({ item }: { item: QuestionFormType }) => {
+interface Props {
+  item: QuestionFormType;
+}
+export const SortableItem = ({ item }: Props) => {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({
       id: item.id,

--- a/src/pages/CreateQuiz/composite/QuizWriteGuideBubble/_quiz_write_guide_bubble.module.scss
+++ b/src/pages/CreateQuiz/composite/QuizWriteGuideBubble/_quiz_write_guide_bubble.module.scss
@@ -5,8 +5,6 @@
   z-index: 999;
   left: 50%;
   transform: translateX(-50%);
-  // top: -85px;
-  // top: -150px;
   .guide {
     position: relative;
     background-color: $gray-00;

--- a/src/pages/CreateQuiz/index.tsx
+++ b/src/pages/CreateQuiz/index.tsx
@@ -25,13 +25,17 @@ import { useBlocker, useNavigate, useParams } from "react-router-dom";
 import { quizKeys } from "@/data/queryKeys.ts";
 import { quizService } from "@/services/server/quizService.ts";
 import { useQuery } from "@tanstack/react-query";
-import { EditScope, QuizCreationType, ViewScope } from "@/types/QuizType.ts";
+import {
+  EditScopeType,
+  QuizFormType,
+  ViewScopeType,
+} from "@/types/QuizType.ts";
 import { BookType } from "@/types/BookType.ts";
 import { bookService } from "@/services/server/bookService.ts";
 import { studyGroupService } from "@/services/server/studyGroupService.ts";
 import { StudyGroupType } from "@/types/StudyGroupType.ts";
-import { SelectOptionType } from "@/types/QuizType.ts";
-import { QuizQuestionType } from "@/types/QuizType.ts";
+import { SelectOptionFormType } from "@/types/QuizType.ts";
+import { QuizQuestionFormType } from "@/types/QuizType.ts";
 import { resetQuizCreationBookStateAtom } from "@/store/quizAtom.ts";
 import usePreventLeave from "@/hooks/usePreventLeave.ts";
 import { currentUserAtom } from "@/store/userAtom.ts";
@@ -114,10 +118,10 @@ export default function Index() {
             profileImageUrl: studyGroupDetail?.profileImageUrl,
           };
         }
-        const prevQuestions: QuizQuestionType[] = await Promise.all(
+        const prevQuestions: QuizQuestionFormType[] = await Promise.all(
           prevQuiz?.questions.map(async (q) => {
             const images = await convertUrlsToImg(q.answerExplanationImages);
-            const selectOptions: SelectOptionType[] = q.selectOptions.map(
+            const selectOptions: SelectOptionFormType[] = q.selectOptions.map(
               (optionText, index) => ({
                 id: index, // TODO: index로 해도 되는지 확인 필요
                 option: optionText,
@@ -137,12 +141,12 @@ export default function Index() {
           }) ?? [],
         );
 
-        const quiz: QuizCreationType = {
+        const quiz: QuizFormType = {
           title: prevQuiz?.title ?? "",
           description: prevQuiz?.description ?? "",
           book: formattedBook,
-          viewScope: prevQuiz?.viewScope as ViewScope,
-          editScope: "CREATOR" as EditScope,
+          viewScope: prevQuiz?.viewScope as ViewScopeType,
+          editScope: "CREATOR" as EditScopeType,
           studyGroup: formattedStudyGroup,
           questions: prevQuestions,
         };

--- a/src/pages/CreateQuiz/layout/QuizCreationFormLayout/QuizCreationFormLayout.tsx
+++ b/src/pages/CreateQuiz/layout/QuizCreationFormLayout/QuizCreationFormLayout.tsx
@@ -11,9 +11,9 @@ import {
   quizCreationStepAtom,
 } from "@/store/quizAtom";
 import {
-  QuizCreationType,
-  QuizQuestionRequestApiType,
-  QuizRequestType,
+  QuizFormType,
+  QuizQuestionCreateType,
+  QuizCreateType,
 } from "@/types/QuizType";
 import { imageService } from "@/services/server/imageService";
 import { errorModalTitleAtom, openErrorModalAtom } from "@/store/quizAtom";
@@ -30,24 +30,25 @@ import { preventLeaveModalAtom } from "@/store/quizAtom";
 import { Blocker } from "react-router-dom";
 import { useValidateQuizForm } from "@/hooks/useValidateQuizForm";
 import { QUIZ_CREATION_STEP } from "@/data/constants";
+interface Props {
+  isEditMode: boolean;
+  editQuizId?: string;
+  steps: Step[];
+  blocker: Blocker;
+}
 
 export default function QuizCreationFormLayout({
   isEditMode,
   editQuizId,
   steps,
   blocker,
-}: {
-  isEditMode: boolean;
-  editQuizId?: string;
-  steps: Step[];
-  blocker: Blocker;
-}) {
+}: Props) {
   const navigate = useNavigate();
   const [currentStep, setCurrentStep] = useAtom(quizCreationStepAtom);
   const [isQuizNextButtonEnabled] = useAtom<boolean>(
     isQuizNextButtonEnabledAtom,
   );
-  const [quizCreationInfo] = useAtom<QuizCreationType>(quizCreationInfoAtom);
+  const [quizCreationInfo] = useAtom<QuizFormType>(quizCreationInfoAtom);
   const [, setErrorModalTitle] = useAtom(errorModalTitleAtom);
   const [openModal] = useAtom(openErrorModalAtom);
   const [, setInvalidQuestionFormId] = useAtom(invalidQuestionFormIdAtom);
@@ -136,9 +137,7 @@ export default function QuizCreationFormLayout({
     return [...alreadyUploadedList, ...uploadedImgUrl];
   };
 
-  const setRequestQuestion = async (): Promise<
-    QuizQuestionRequestApiType[]
-  > => {
+  const setRequestQuestion = async (): Promise<QuizQuestionCreateType[]> => {
     const uploadedImgQuestions = quizCreationInfo.questions!.map(
       async (question) => {
         const { id, ...rest } = question;
@@ -165,7 +164,7 @@ export default function QuizCreationFormLayout({
   const { mutate: createQuiz } = useMutation<
     { id: number } | null,
     ErrorType,
-    QuizRequestType
+    QuizCreateType
   >({
     mutationFn: (quiz) => quizService.createQuiz(quiz),
     onSuccess: (data) => {
@@ -200,7 +199,7 @@ export default function QuizCreationFormLayout({
   const { mutate: requestModifyQuiz } = useMutation<
     void,
     ErrorType,
-    { editQuizId: string; quiz: QuizRequestType }
+    { editQuizId: string; quiz: QuizCreateType }
   >({
     mutationFn: ({ editQuizId, quiz }) =>
       quizService.modifyQuiz({ editQuizId, quiz }),
@@ -232,7 +231,7 @@ export default function QuizCreationFormLayout({
       return;
     }
 
-    const quiz: QuizRequestType = {
+    const quiz: QuizCreateType = {
       title: quizCreationInfo.title,
       description: quizCreationInfo.description,
       viewScope: quizCreationInfo.viewScope,

--- a/src/pages/CreateQuiz/layout/QuizCreationSteps/QuizCreationSteps.tsx
+++ b/src/pages/CreateQuiz/layout/QuizCreationSteps/QuizCreationSteps.tsx
@@ -21,13 +21,12 @@ import {
   openErrorModalAtom,
 } from "@/store/quizAtom";
 import { useValidateQuizForm } from "@/hooks/useValidateQuizForm";
-export default function QuizCreationSteps({
-  isEditMode,
-  steps,
-}: {
+interface Props {
   isEditMode: boolean;
   steps: Step[];
-}) {
+}
+
+export default function QuizCreationSteps({ isEditMode, steps }: Props) {
   const [currentStep, setCurrentStep] = useAtom(quizCreationStepAtom);
   const quizInfo = useAtomValue(quizCreationInfoAtom);
   const setInvalidQuestionFormId = useSetAtom(invalidQuestionFormIdAtom);

--- a/src/pages/FindPassword/composite/SendTemporaryPassword/SendTemporaryPassword.tsx
+++ b/src/pages/FindPassword/composite/SendTemporaryPassword/SendTemporaryPassword.tsx
@@ -10,12 +10,10 @@ import { authService } from "@/services/server/authService";
 import { useMutation } from "@tanstack/react-query";
 import { ErrorType } from "@/types/ErrorType";
 import { findPasswordEmailAtom } from "@/store/userAtom";
-
-export default function SendTemporaryPassword({
-  setStep,
-}: {
+interface Props {
   setStep: Dispatch<SetStateAction<number>>;
-}) {
+}
+export default function SendTemporaryPassword({ setStep }: Props) {
   const { value: email, onChange: onEmailChange } = useInput("");
   const [isEmailReadyToSend, setIsEmailReadyToSend] = useState<boolean>(false);
   const [, setFindPasswordEmail] = useAtom(findPasswordEmailAtom);

--- a/src/pages/Home/components/composite/BookItem/BookItem.tsx
+++ b/src/pages/Home/components/composite/BookItem/BookItem.tsx
@@ -1,8 +1,10 @@
 import styles from "./_bookItem.module.scss";
 import { BookType } from "@/types/BookType.ts";
 import pencil from "/assets/svg/bookList/pencil.svg";
-
-export default function BookItem({ book }: { book: BookType }) {
+interface Props {
+  book: BookType;
+}
+export default function BookItem({ book }: Props) {
   const bookAuthor =
     book.authors.length > 1 ? `${book.authors[0]} 외` : book.authors;
 

--- a/src/pages/MyPage/components/QuizItem/_quiz_item.module.scss
+++ b/src/pages/MyPage/components/QuizItem/_quiz_item.module.scss
@@ -9,6 +9,7 @@
   flex-direction: row;
   gap: 16px;
   height: 280px;
+  width: 420px;
 
   .left-container,
   .right-container {
@@ -26,11 +27,11 @@
       display: flex;
       justify-content: center;
       align-items: start;
-      height: 208px;
+      max-height: 210px;
 
       .img {
         max-width: 140px;
-        height: auto;
+        max-height: 100%;
         border-radius: 6px;
       }
     }
@@ -43,8 +44,11 @@
       margin-bottom: 8px;
     }
     .title {
+      @include text-ellipsis;
       font-size: $font-size-large;
       font-weight: $font-weight-semibold;
+      min-width: 0;
+      width: 220px;
     }
     .copy-link {
       padding: 4px;
@@ -90,6 +94,7 @@
       color: $gray-70;
       font-size: $font-size-small;
       font-weight: $font-weight-regular;
+      @include text-ellipsis(5);
     }
 
     .button-container {

--- a/src/pages/MyPage/composite/MyMadeQuiz/MyMadeQuiz.tsx
+++ b/src/pages/MyPage/composite/MyMadeQuiz/MyMadeQuiz.tsx
@@ -8,7 +8,7 @@ import useFilter from "@/hooks/useFilter";
 import { myMadeQuizPaginationAtom } from "@/store/paginationAtom";
 import Pagination from "@/components/composite/Pagination/Pagination";
 import { FilterOptionType } from "@/components/composite/ListFilter/ListFilter";
-import { FetchMyQuizzesParams } from "@/types/ParamsType";
+import { MyQuizzesFetchType } from "@/types/ParamsType";
 import { useEffect } from "react";
 import ROUTES from "@/data/routes";
 import { MyMadeQuizzesFilterType } from "@/types/FilterType";
@@ -43,7 +43,7 @@ export default function MyMadeQuiz() {
   );
   const totalPagesLength = paginationState.totalPagesLength;
 
-  const params: FetchMyQuizzesParams = {
+  const params: MyQuizzesFetchType = {
     page: paginationState.currentPage.toString() ?? "1",
     sort: filterCriteria.sort,
     direction: filterCriteria.direction,

--- a/src/pages/MyPage/composite/MyMadeQuiz/MyMadeQuiz.tsx
+++ b/src/pages/MyPage/composite/MyMadeQuiz/MyMadeQuiz.tsx
@@ -9,7 +9,7 @@ import { myMadeQuizPaginationAtom } from "@/store/paginationAtom";
 import Pagination from "@/components/composite/Pagination/Pagination";
 import { FilterOptionType } from "@/components/composite/ListFilter/ListFilter";
 import { MyQuizzesFetchType } from "@/types/ParamsType";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import ROUTES from "@/data/routes";
 import { MyMadeQuizzesFilterType } from "@/types/FilterType";
 import { myMadeQuizzesFilterAtom } from "@/store/filterAtom";
@@ -76,6 +76,10 @@ export default function MyMadeQuiz() {
 
   const myQuizzes = myQuizzesData?.data;
 
+  const shouldRenderPagination = useMemo(() => {
+    return (totalPagesLength ?? 0) > 0;
+  }, [totalPagesLength]);
+
   if (isLoading || !myQuizzes) {
     return <LoadingSpinner pageCenter width={40} />;
   }
@@ -92,14 +96,14 @@ export default function MyMadeQuiz() {
         filterCriteria={filterCriteria}
         filterOptions={filterOptions}
       />
-      {totalPagesLength && totalPagesLength > 0 && (
+      {shouldRenderPagination ? (
         <Pagination
           type="queryString"
           parentPage={"my/made-quiz"}
           paginationState={paginationState}
           setPaginationState={setPaginationState}
         />
-      )}
+      ) : null}
     </>
   );
 }

--- a/src/pages/MyPage/composite/MyStudyGroups/MyStudyGroups.tsx
+++ b/src/pages/MyPage/composite/MyStudyGroups/MyStudyGroups.tsx
@@ -11,7 +11,7 @@ import ListFilter, {
 } from "@/components/composite/ListFilter/ListFilter";
 import { useRef } from "react";
 import { parseQueryParams } from "@/utils/parseQueryParams";
-import { FetchStudyGroupsParams } from "@/types/ParamsType";
+import { StudyGroupsFetchType } from "@/types/ParamsType";
 import { NoDataSection } from "@/components/composite/NoDataSection/NoDataSection";
 import StudyGroupButton from "../../components/StudyGroupButton/StudyGroupButton";
 import textBox from "/public/assets/svg/myPage/textBox.svg";
@@ -72,7 +72,7 @@ export default function MyStudyGroups() {
     }
   >({
     queryKey: studyGroupKeys.list(
-      parseQueryParams<StudyGroupsSortType, FetchStudyGroupsParams>({
+      parseQueryParams<StudyGroupsSortType, StudyGroupsFetchType>({
         sort,
         direction,
         page,

--- a/src/pages/MyPage/composite/SolvedQuiz/SolvedQuiz.tsx
+++ b/src/pages/MyPage/composite/SolvedQuiz/SolvedQuiz.tsx
@@ -8,7 +8,7 @@ import useFilter from "@/hooks/useFilter";
 import { mySolvedQuizPaginationAtom } from "@/store/paginationAtom";
 import Pagination from "@/components/composite/Pagination/Pagination";
 import { FilterOptionType } from "@/components/composite/ListFilter/ListFilter";
-import { FetchMyQuizzesParams } from "@/types/ParamsType";
+import { MyQuizzesFetchType } from "@/types/ParamsType";
 import { useEffect } from "react";
 import ROUTES from "@/data/routes";
 import { MySolvedQuizzesFilterType } from "@/types/FilterType";
@@ -43,7 +43,7 @@ export default function SolvedQuiz() {
   );
 
   const totalPagesLength = paginationState.totalPagesLength;
-  const params: FetchMyQuizzesParams = {
+  const params: MyQuizzesFetchType = {
     page: paginationState.currentPage.toString() ?? "1",
     sort: filterCriteria.sort,
     direction: filterCriteria.direction,

--- a/src/pages/MyPage/composite/SolvedQuiz/SolvedQuiz.tsx
+++ b/src/pages/MyPage/composite/SolvedQuiz/SolvedQuiz.tsx
@@ -9,7 +9,7 @@ import { mySolvedQuizPaginationAtom } from "@/store/paginationAtom";
 import Pagination from "@/components/composite/Pagination/Pagination";
 import { FilterOptionType } from "@/components/composite/ListFilter/ListFilter";
 import { MyQuizzesFetchType } from "@/types/ParamsType";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import ROUTES from "@/data/routes";
 import { MySolvedQuizzesFilterType } from "@/types/FilterType";
 import { mySolvedQuizFilterAtom } from "@/store/filterAtom";
@@ -76,10 +76,14 @@ export default function SolvedQuiz() {
 
   const myQuizzes = myQuizzesData?.data;
 
+  const shouldRenderDataList = !isLoading && myQuizzes;
+  const shouldRenderPagination = useMemo(() => {
+    return (totalPagesLength ?? 0) > 0;
+  }, [totalPagesLength]);
+
   return (
-    !isLoading &&
-    myQuizzes && (
-      <div>
+    shouldRenderDataList && (
+      <>
         <QuizListLayout
           title="푼 퀴즈"
           quizzes={myQuizzes}
@@ -90,15 +94,15 @@ export default function SolvedQuiz() {
           filterCriteria={filterCriteria}
           filterOptions={filterOptions}
         />
-        {totalPagesLength && totalPagesLength > 0 && (
+        {shouldRenderPagination ? (
           <Pagination
             type="queryString"
             parentPage="my/solved-quiz"
             paginationState={paginationState}
             setPaginationState={setPaginationState}
           />
-        )}
-      </div>
+        ) : null}
+      </>
     )
   );
 }

--- a/src/pages/MyPage/composite/StudyGroupSolvedQuiz/studyGroupSolvedQuiz.tsx
+++ b/src/pages/MyPage/composite/StudyGroupSolvedQuiz/studyGroupSolvedQuiz.tsx
@@ -5,7 +5,7 @@ import {
   MyStudySolvedQuizzesSortType,
 } from "@/types/FilterType";
 import { parseQueryParams } from "@/utils/parseQueryParams";
-import { FetchStudyGroupsParams } from "@/types/ParamsType";
+import { StudyGroupsFetchType } from "@/types/ParamsType";
 import { useAtom } from "jotai";
 import { mySolvedQuizPaginationAtom } from "@/store/paginationAtom";
 import { myStudySolvedQuizFilterAtom } from "@/store/filterAtom";
@@ -64,7 +64,7 @@ export default function StudyGroupSolvedQuiz({ studyGroupId }: Props) {
   const { data: solvedQuizData } = useQuery({
     queryKey: studyGroupKeys.mySolvedQuizList(
       studyGroupId,
-      parseQueryParams<MyStudySolvedQuizzesSortType, FetchStudyGroupsParams>({
+      parseQueryParams<MyStudySolvedQuizzesSortType, StudyGroupsFetchType>({
         sort,
         direction,
         page,
@@ -77,7 +77,7 @@ export default function StudyGroupSolvedQuiz({ studyGroupId }: Props) {
             studyGroupId,
             parseQueryParams<
               MyStudySolvedQuizzesSortType,
-              FetchStudyGroupsParams
+              StudyGroupsFetchType
             >({
               sort,
               direction,

--- a/src/pages/MyPage/composite/StudyGroupSolvedQuiz/studyGroupSolvedQuiz.tsx
+++ b/src/pages/MyPage/composite/StudyGroupSolvedQuiz/studyGroupSolvedQuiz.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import styles from "../StudyGroup/_study_group.module.scss";
 import {
   MyStudySolvedQuizzesFilterType,
@@ -119,6 +119,10 @@ export default function StudyGroupSolvedQuiz({ studyGroupId }: Props) {
     );
   };
 
+  const shouldRenderPagination = useMemo(() => {
+    return (totalPagesLength ?? 0) > 0;
+  }, [totalPagesLength]);
+
   return (
     <section className={styles.section}>
       <div className={styles["filter-container"]}>
@@ -146,7 +150,7 @@ export default function StudyGroupSolvedQuiz({ studyGroupId }: Props) {
       ) : (
         <NoDataSection title="아직 제출한 퀴즈가 없어요 😔" />
       )}
-      {totalPagesLength && isQuizzesExist ? (
+      {shouldRenderPagination ? (
         <Pagination
           type="state"
           paginationState={paginationState}

--- a/src/pages/MyPage/composite/StudyGroupUnsolvedQuiz/StudyGroupUnsolvedQuiz.tsx
+++ b/src/pages/MyPage/composite/StudyGroupUnsolvedQuiz/StudyGroupUnsolvedQuiz.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import styles from "../StudyGroup/_study_group.module.scss";
 import { parseQueryParams } from "@/utils/parseQueryParams";
-import { FetchStudyGroupsParams } from "@/types/ParamsType";
+import { StudyGroupsFetchType } from "@/types/ParamsType";
 import { useAtom } from "jotai";
 import { myStudyUnsolvedQuizPaginationAtom } from "@/store/paginationAtom";
 import { myStudyUnsolvedQuizFilterAtom } from "@/store/filterAtom";
@@ -71,7 +71,7 @@ export default function StudyGroupUnsolvedQuiz({ studyGroupId }: Props) {
   const { data: unsolvedQuizData } = useQuery({
     queryKey: studyGroupKeys.myUnsolvedQuizList(
       studyGroupId,
-      parseQueryParams<MyStudyUnSolvedQuizzesSortType, FetchStudyGroupsParams>({
+      parseQueryParams<MyStudyUnSolvedQuizzesSortType, StudyGroupsFetchType>({
         sort,
         direction,
         page,
@@ -84,7 +84,7 @@ export default function StudyGroupUnsolvedQuiz({ studyGroupId }: Props) {
             studyGroupId,
             parseQueryParams<
               MyStudyUnSolvedQuizzesSortType,
-              FetchStudyGroupsParams
+              StudyGroupsFetchType
             >({
               sort,
               direction,

--- a/src/pages/MyPage/composite/StudyGroupUnsolvedQuiz/StudyGroupUnsolvedQuiz.tsx
+++ b/src/pages/MyPage/composite/StudyGroupUnsolvedQuiz/StudyGroupUnsolvedQuiz.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import styles from "../StudyGroup/_study_group.module.scss";
 import { parseQueryParams } from "@/utils/parseQueryParams";
 import { StudyGroupsFetchType } from "@/types/ParamsType";
@@ -144,12 +144,16 @@ export default function StudyGroupUnsolvedQuiz({ studyGroupId }: Props) {
     );
   };
 
-  const isQuizzesExist = unsolvedQuizzes && unsolvedQuizzes.length > 0;
+  const shouldRenderDataList = unsolvedQuizzes && unsolvedQuizzes.length > 0;
+  const shouldRenderPagination = useMemo(() => {
+    return (totalPagesLength ?? 0) > 0;
+  }, [totalPagesLength]);
+
   return (
     <section>
       <div className={styles["filter-container"]}>
         <h3 className={styles.title}>풀어야 할 퀴즈</h3>
-        {isQuizzesExist ? (
+        {shouldRenderDataList ? (
           <ListFilter
             onOptionClick={handleOptionClick}
             sortFilter={filterCriteria}
@@ -157,7 +161,7 @@ export default function StudyGroupUnsolvedQuiz({ studyGroupId }: Props) {
           />
         ) : null}
       </div>
-      {isQuizzesExist ? (
+      {shouldRenderDataList ? (
         <ol className={styles["quiz-list"]}>
           {unsolvedQuizzes.map((quizData) => (
             <QuizItem
@@ -176,7 +180,7 @@ export default function StudyGroupUnsolvedQuiz({ studyGroupId }: Props) {
           onClick={() => handleAuthenticatedAction(handleGoToCreateQuiz)}
         />
       )}
-      {totalPagesLength && isQuizzesExist ? (
+      {shouldRenderPagination ? (
         <Pagination
           type="state"
           paginationState={paginationState}

--- a/src/pages/MyPage/composite/quizItem/MyMadeQuizItem/MyMadeQuizItem.tsx
+++ b/src/pages/MyPage/composite/quizItem/MyMadeQuizItem/MyMadeQuizItem.tsx
@@ -9,13 +9,7 @@ import { MyQuizDataType } from "@/types/QuizType";
 import { Link } from "react-router-dom";
 
 // 만든 퀴즈 아이템
-export default function MyMadeQuizItem({
-  myQuiz,
-  formattedDate,
-  onModifyQuiz,
-  onClickDelete,
-  onCopyQuizLink,
-}: {
+interface Props {
   myQuiz: MyQuizDataType;
   formattedDate: string;
   onModifyQuiz: (
@@ -30,7 +24,14 @@ export default function MyMadeQuizItem({
     e: React.MouseEvent<HTMLButtonElement>,
     quizId: number,
   ) => void;
-}) {
+}
+export default function MyMadeQuizItem({
+  myQuiz,
+  formattedDate,
+  onModifyQuiz,
+  onClickDelete,
+  onCopyQuizLink,
+}: Props) {
   const { isTooltipVisible, showTooltip, hideTooltip } = useTooltip();
 
   return (

--- a/src/pages/MyPage/composite/quizItem/SolvedQuizItem/SolvedQuizItem.tsx
+++ b/src/pages/MyPage/composite/quizItem/SolvedQuizItem/SolvedQuizItem.tsx
@@ -9,12 +9,7 @@ import { MySolvedQuizDataType } from "@/types/QuizType";
 import { Link } from "react-router-dom";
 
 // 푼 퀴즈 아이템
-export default function SolvedQuizItem({
-  myQuiz,
-  formattedDate,
-  onReSolveQuiz,
-  onCopyQuizLink,
-}: {
+interface Props {
   myQuiz: MySolvedQuizDataType;
   formattedDate: string;
   onReSolveQuiz: (
@@ -25,7 +20,14 @@ export default function SolvedQuizItem({
     e: React.MouseEvent<HTMLButtonElement>,
     quizId: number,
   ) => void;
-}) {
+}
+
+export default function SolvedQuizItem({
+  myQuiz,
+  formattedDate,
+  onReSolveQuiz,
+  onCopyQuizLink,
+}: Props) {
   const { isTooltipVisible, showTooltip, hideTooltip } = useTooltip();
 
   return (

--- a/src/pages/MyPage/layout/QuizListLayout/QuizListLayout.tsx
+++ b/src/pages/MyPage/layout/QuizListLayout/QuizListLayout.tsx
@@ -13,7 +13,16 @@ import { useState } from "react";
 import SolvedQuizItem from "../../composite/quizItem/SolvedQuizItem/SolvedQuizItem";
 import MyMadeQuizItem from "../../composite/quizItem/MyMadeQuizItem/MyMadeQuizItem";
 import { copyText } from "@/utils/copyText";
-
+interface Props<T extends { sort: string; direction: string }> {
+  title: string;
+  quizzes: MyQuizDataType[] | MySolvedQuizDataType[];
+  titleWhenNoData: string;
+  buttonNameWhenNoData: string;
+  onClickBtnWhenNoData: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  handleOptionClick: (filter: T) => void;
+  filterCriteria: T;
+  filterOptions: FilterOptionType<T>[];
+}
 export default function QuizListLayout<
   T extends { sort: string; direction: string },
 >({
@@ -25,16 +34,7 @@ export default function QuizListLayout<
   handleOptionClick,
   filterCriteria,
   filterOptions,
-}: {
-  title: string;
-  quizzes: MyQuizDataType[] | MySolvedQuizDataType[];
-  titleWhenNoData: string;
-  buttonNameWhenNoData: string;
-  onClickBtnWhenNoData: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  handleOptionClick: (filter: T) => void;
-  filterCriteria: T;
-  filterOptions: FilterOptionType<T>[];
-}) {
+}: Props<T>) {
   const navigate = useNavigate();
   const { isModalOpen, openModal, closeModal } = useModal();
   const [quizId, setQuizId] = useState<string>();

--- a/src/pages/QuizDetail/components/QuizDifficultyChart/QuizDifficultyChart.tsx
+++ b/src/pages/QuizDetail/components/QuizDifficultyChart/QuizDifficultyChart.tsx
@@ -11,17 +11,17 @@ export default function QuizDifficultyChart({ difficulty }: Props) {
     <div className={styles.container}>
       {difficulty
         ? Object.entries(difficulty)
-          .reverse()
-          .map(([level, data]) => (
-            <DifficultyLevelItem key={level} level={level} data={data} />
-          ))
+            .reverse()
+            .map(([level, data]) => (
+              <DifficultyLevelItem key={level} level={level} data={data} />
+            ))
         : [1, 2, 3].map((level) => (
-          <DifficultyLevelItem
-            key={level}
-            level={level.toString()}
-            data={{ selectCount: 0, selectRate: 0 }}
-          />
-        ))}
+            <DifficultyLevelItem
+              key={level}
+              level={level.toString()}
+              data={{ selectCount: 0, selectRate: 0 }}
+            />
+          ))}
     </div>
   );
 }

--- a/src/pages/QuizDetail/components/ReviewItem/ReviewItem.tsx
+++ b/src/pages/QuizDetail/components/ReviewItem/ReviewItem.tsx
@@ -1,4 +1,4 @@
-import { ReviewPostType, ReviewType } from "@/types/ReviewType";
+import { ReviewCreateType, ReviewType } from "@/types/ReviewType";
 import styles from "./_review_item.module.scss";
 import FiveStar from "@/components/composite/FiveStar/FiveStar";
 import { formatDate } from "@/utils/formatDate";
@@ -66,7 +66,7 @@ export default function ReviewItem({ review, isMyReview, quizTitle }: Props) {
   const { mutate: updateReview } = useMutation<
     void,
     ErrorType,
-    { id: number; review: ReviewPostType }
+    { id: number; review: ReviewCreateType }
   >({
     mutationFn: ({ id, review }) =>
       reviewService.updateQuizReview({
@@ -127,7 +127,7 @@ export default function ReviewItem({ review, isMyReview, quizTitle }: Props) {
   });
 
   const handleUpdateReview = () => {
-    const reviewToUpdate: ReviewPostType = {
+    const reviewToUpdate: ReviewCreateType = {
       starRating: starRating,
       difficultyLevel: difficultyLevel,
       comment: comment,

--- a/src/pages/QuizDetail/composite/ReviewList/ReviewList.tsx
+++ b/src/pages/QuizDetail/composite/ReviewList/ReviewList.tsx
@@ -13,7 +13,7 @@ import { currentUserAtom } from "@/store/userAtom";
 import { ReviewsFilterType, ReviewsSortType } from "@/types/FilterType";
 import { parseQueryParams } from "@/utils/parseQueryParams";
 import { useLocation } from "react-router-dom";
-import { FetchReviewsParams } from "@/types/ParamsType";
+import { ReviewsFetchType } from "@/types/ParamsType";
 import { ReviewType } from "@/types/ReviewType";
 import { ErrorType } from "@/types/ErrorType";
 import { useRef } from "react";
@@ -90,7 +90,7 @@ export default function ReviewList({ quizId, quizTitle }: Props) {
     }
   >({
     queryKey: reviewKeys.list(
-      parseQueryParams<ReviewsSortType, FetchReviewsParams>({
+      parseQueryParams<ReviewsSortType, ReviewsFetchType>({
         sort,
         direction,
         page,

--- a/src/pages/QuizResult/composite/CommonQuizResult.tsx
+++ b/src/pages/QuizResult/composite/CommonQuizResult.tsx
@@ -6,12 +6,11 @@ import { quizService } from "@/services/server/quizService";
 import { quizKeys } from "@/data/queryKeys";
 import solvingQuizCompleteImage from "/public/assets/image/solving-quiz-complete.png";
 import LoadingSpinner from "@/components/atom/LoadingSpinner/LoadingSpinner";
-
-export default function CommonQuizResult({
-  solvingQuizId,
-}: {
+interface Props {
   solvingQuizId: string;
-}) {
+}
+
+export default function CommonQuizResult({ solvingQuizId }: Props) {
   const { data, isLoading } = useQuery({
     queryKey: quizKeys.result(solvingQuizId),
     queryFn: () => quizService.fetchGradeResult(solvingQuizId),

--- a/src/pages/QuizResult/composite/StudyQuizResult.tsx
+++ b/src/pages/QuizResult/composite/StudyQuizResult.tsx
@@ -13,14 +13,11 @@ import { studyGroupService } from "@/services/server/studyGroupService";
 import { useNavigate } from "react-router-dom";
 import ROUTES from "@/data/routes";
 import LoadingSpinner from "@/components/atom/LoadingSpinner/LoadingSpinner";
-
-export default function StudyQuizResult({
-  studyGroupId,
-  quizId,
-}: {
+interface Props {
   studyGroupId: string;
   quizId: string;
-}) {
+}
+export default function StudyQuizResult({ studyGroupId, quizId }: Props) {
   const [currentUser] = useAtom(currentUserAtom);
   const navigate = useNavigate();
 

--- a/src/pages/QuizResult/index.tsx
+++ b/src/pages/QuizResult/index.tsx
@@ -6,7 +6,7 @@ import { useParams } from "react-router-dom";
 import StudyQuizResult from "./composite/StudyQuizResult";
 import { useState } from "react";
 import ROUTES from "@/data/routes";
-import { QuizReviewRouteParams } from "@/types/ParamsType";
+import { QuizReviewRouteType } from "@/types/ParamsType";
 
 export default function Index() {
   const [currentStep, setCurrentStep] = useState<number>(0);
@@ -32,7 +32,7 @@ export default function Index() {
   ];
 
   const goToReviewPage = () => {
-    const params: QuizReviewRouteParams = {
+    const params: QuizReviewRouteType = {
       quizId: parseInt(quizId!),
       solvingQuizId: parseInt(solvingQuizId!),
       quizTitle: quizTitle!,

--- a/src/pages/QuizReview/index.tsx
+++ b/src/pages/QuizReview/index.tsx
@@ -11,7 +11,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { ErrorType } from "@/types/ErrorType";
 import { reviewService } from "@/services/server/reviewService";
 import { useParams } from "react-router-dom";
-import { ReviewPostType } from "@/types/ReviewType";
+import { ReviewCreateType } from "@/types/ReviewType";
 import ROUTES from "@/data/routes";
 import { reviewKeys } from "@/data/queryKeys";
 
@@ -32,7 +32,7 @@ export default function Index() {
   const { mutate: submitQuizReview } = useMutation<
     void,
     ErrorType,
-    ReviewPostType
+    ReviewCreateType
   >({
     mutationFn: async (newQuizReview) => {
       if (myReview) {
@@ -82,7 +82,7 @@ export default function Index() {
     if (!difficultyLevel?.difficultyValue || !quizId) {
       return;
     }
-    const review: ReviewPostType = {
+    const review: ReviewCreateType = {
       starRating: rating,
       difficultyLevel: difficultyLevel?.difficultyValue,
       comment: value,

--- a/src/pages/Register/components/CheckBox/CheckBox.tsx
+++ b/src/pages/Register/components/CheckBox/CheckBox.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode } from "react";
 import { gray00, gray40, primary } from "@/styles/abstracts/colors.ts";
 import { Check } from "@/svg/Check";
 
-interface CheckBoxProps {
+interface Props {
   id: string;
   checked: boolean;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -24,7 +24,7 @@ export default function CheckBox({
   disabled,
   autoFocus = false,
   LabelComponent,
-}: CheckBoxProps) {
+}: Props) {
   const className = `${styles.label} ${
     styles[isOutLined ? "outlined" : "none"]
   }`;

--- a/src/pages/Register/components/ProfileUploader/ProfileUploader.tsx
+++ b/src/pages/Register/components/ProfileUploader/ProfileUploader.tsx
@@ -4,18 +4,18 @@ import { InfoFilled } from "@/svg/InfoFilled";
 import { gray40, gray60 } from "@/styles/abstracts/colors.ts";
 import Button from "@/components/atom/Button/Button";
 import { ProfileImageState } from "../../composite/ProfileSet/ProfileSet";
-
+interface Props {
+  email: string;
+  profileImage: ProfileImageState;
+  setProfileImage: React.Dispatch<React.SetStateAction<ProfileImageState>>;
+  defaultImageUrl: string;
+}
 export default function ProfileUploader({
   email,
   profileImage,
   setProfileImage,
   defaultImageUrl,
-}: {
-  email: string;
-  profileImage: ProfileImageState;
-  setProfileImage: React.Dispatch<React.SetStateAction<ProfileImageState>>;
-  defaultImageUrl: string;
-}) {
+}: Props) {
   const onDeleteProfileImage = () => {
     setProfileImage({
       url: defaultImageUrl,

--- a/src/pages/Register/composite/TermsAgreement/TermsAgreement.tsx
+++ b/src/pages/Register/composite/TermsAgreement/TermsAgreement.tsx
@@ -19,12 +19,10 @@ import { authService } from "@/services/server/authService";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { authKeys } from "@/data/queryKeys";
 import { ErrorType } from "@/types/ErrorType";
-
-export default function TermsAgreement({
-  setStep,
-}: {
+interface Props {
   setStep: Dispatch<SetStateAction<number>>;
-}) {
+}
+export default function TermsAgreement({ setStep }: Props) {
   const { method } = useParams();
 
   const { isModalOpen, openModal, closeModal } = useModal();

--- a/src/pages/Register/composite/email/PasswordSet/PasswordSet.tsx
+++ b/src/pages/Register/composite/email/PasswordSet/PasswordSet.tsx
@@ -12,12 +12,10 @@ import { Invisible } from "@/svg/Invisible";
 import { Visible } from "@/svg/Visible";
 import PasswordValidationMessage from "@/components/atom/PasswordValidationMessage/PasswordValidationMessage";
 import PasswordMatchCheckMessage from "@/components/atom/PasswordMatchCheckMessage/PasswordMatchCheckMessage";
-
-export default function PasswordSet({
-  setStep,
-}: {
+interface Props {
   setStep: Dispatch<SetStateAction<number>>;
-}) {
+}
+export default function PasswordSet({ setStep }: Props) {
   const {
     value: password,
     onChange: onPasswordChange,

--- a/src/pages/Register/composite/email/Verification/Verification.tsx
+++ b/src/pages/Register/composite/email/Verification/Verification.tsx
@@ -16,12 +16,10 @@ import { ErrorType } from "@/types/ErrorType";
 import toast from "react-hot-toast";
 import CodeInput from "@/components/composite/CodeInput/CodeInput";
 import useCodeInput from "@/hooks/useCodeInput";
-
-export default function Verification({
-  setStep,
-}: {
+interface Props {
   setStep: Dispatch<SetStateAction<number>>;
-}) {
+}
+export default function Verification({ setStep }: Props) {
   const [user, setUser] = useAtom<RegisterInfoType>(registerInfoAtom);
   const {
     value: email,

--- a/src/pages/SolveQuiz/composite/ProgressBar.tsx
+++ b/src/pages/SolveQuiz/composite/ProgressBar.tsx
@@ -3,16 +3,16 @@ import styles from "./_progress_bar.module.scss";
 import { Check } from "@/svg/Check";
 import { gray00 } from "@/styles/abstracts/colors";
 import { Close } from "@/svg/Close";
-
+interface Props {
+  questions: SolvingQuizQuestionType[];
+  currentStep: number;
+  isAnswerCorrects: boolean[];
+}
 export default function ProgressBar({
   currentStep,
   questions,
   isAnswerCorrects,
-}: {
-  questions: SolvingQuizQuestionType[];
-  currentStep: number;
-  isAnswerCorrects: boolean[];
-}) {
+}: Props) {
   return (
     <section className={styles["progress-bar"]}>
       {questions.map((_, index) => {

--- a/src/pages/SolveQuiz/composite/SolvingQuizForm.tsx
+++ b/src/pages/SolveQuiz/composite/SolvingQuizForm.tsx
@@ -13,12 +13,21 @@ import { Close } from "@/svg/Close";
 import { gray00 } from "@/styles/abstracts/colors";
 import CheckBox from "@/components/atom/Checkbox/Checkbox";
 import { CheckboxStatusType } from "@/components/atom/Checkbox/Checkbox";
-import { CheckBoxOption } from "@/types/CheckBoxTypes";
+import { CheckBoxOptionType } from "@/types/CheckBoxTypes";
 import ReactMarkdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import "highlight.js/styles/xcode.css";
 
 //TODO: 중복함수 리팩토링 필요
+interface Props {
+  formIndex: number;
+  question: SolvingQuizQuestionType;
+  optionDisabled: boolean;
+  setSubmitDisabled: React.Dispatch<React.SetStateAction<boolean>>;
+  correctAnswer: string[];
+  isAnswerCorrects: boolean[];
+  didAnswerChecked: boolean;
+}
 export default function SolvingQuizForm({
   formIndex,
   question,
@@ -27,15 +36,7 @@ export default function SolvingQuizForm({
   optionDisabled,
   isAnswerCorrects,
   didAnswerChecked,
-}: {
-  formIndex: number;
-  question: SolvingQuizQuestionType;
-  optionDisabled: boolean;
-  setSubmitDisabled: React.Dispatch<React.SetStateAction<boolean>>;
-  correctAnswer: string[];
-  isAnswerCorrects: boolean[];
-  didAnswerChecked: boolean;
-}) {
+}: Props) {
   const [, setSelectedOptions] = useAtom(selectedOptionsAtom);
   const {
     selectedValue: selectedRadioOption,
@@ -177,7 +178,7 @@ export default function SolvingQuizForm({
     return (
       <>
         {question.selectOptions.map((option, index) => {
-          const checkBoxOption: CheckBoxOption = {
+          const checkBoxOption: CheckBoxOptionType = {
             id: index,
             value: index.toString(),
             label: option.content,

--- a/src/pages/SolveQuiz/index.tsx
+++ b/src/pages/SolveQuiz/index.tsx
@@ -11,13 +11,13 @@ import { ArrowRight } from "@/svg/ArrowRight";
 import { gray00, gray60 } from "@/styles/abstracts/colors";
 import { useAtom } from "jotai";
 import { selectedOptionsAtom } from "@/store/quizAtom";
-import { QuestionCheckedResult } from "@/types/QuizType";
+import { QuestionCheckedResultType } from "@/types/QuizType";
 import ReactMarkdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import "highlight.js/styles/xcode.css";
 import toast from "react-hot-toast";
 import ROUTES from "@/data/routes";
-import { QuizResultRouteParams } from "@/types/ParamsType";
+import { QuizResultRouteType } from "@/types/ParamsType";
 import { ErrorType } from "@/types/ErrorType";
 import useAutoResizeTextarea from "@/hooks/useAutoResizeTextArea";
 import useModal from "@/hooks/useModal";
@@ -239,7 +239,7 @@ export default function Index() {
   const [submitDisabled, setSubmitDisabled] = useState<boolean>(true);
   const [selectedOptions, setSelectedOptions] = useAtom(selectedOptionsAtom);
   const [questionCheckedResult, setQuestionCheckedResult] =
-    useState<QuestionCheckedResult>();
+    useState<QuestionCheckedResultType>();
   const [optionDisabled, setOptionDisabled] = useState<boolean>(false);
   const [didAnswerChecked, setDidAnswerChecked] = useState<boolean>(false);
   const [toggleAnswerDescription, setToggleAnswerDescription] =
@@ -267,7 +267,7 @@ export default function Index() {
     setOptionDisabled(true);
     const questionId: number = quiz!.questions[currentFormIndex].id;
     const solvingQuizIdToString: string = solvingQuizId.toString();
-    const checkedResult: QuestionCheckedResult =
+    const checkedResult: QuestionCheckedResultType =
       await quizService.submitQuestion(
         solvingQuizIdToString,
         questionId,
@@ -292,7 +292,7 @@ export default function Index() {
       const id: string = quizId.toString();
       const solvingId: string = solvingQuizId.toString();
       const quizTitle: string = quiz?.title ?? "";
-      const params: QuizResultRouteParams = {
+      const params: QuizResultRouteType = {
         quizId: parseInt(id),
         solvingQuizId: parseInt(solvingId), // TODO 제거
         quizTitle: quizTitle,

--- a/src/services/server/authService.ts
+++ b/src/services/server/authService.ts
@@ -1,10 +1,10 @@
 // import localApi from "../local/LocalApi.ts";
-import { TermsOfServiceType } from "@/types/TermsOfServiceType.ts";
+import { TermsOfServiceType as TermsOfServiceFetchType } from "@/types/TermsOfServiceType.ts";
 import { UserType } from "@/types/UserType.ts";
 import { axiosInstance } from "@/config/axiosConfig.ts";
 import { handleAxiosError } from "@/utils/errorHandler.ts";
 import { SocialLoginType } from "@/types/SocialLoginType.ts";
-import { UpdateUserParams } from "@/types/ParamsType";
+import { UserUpdateType } from "@/types/ParamsType";
 
 class AuthService {
   // 소셜 회원가입
@@ -77,7 +77,7 @@ class AuthService {
   };
 
   // 문서 상에는 'modify login member' 로 명시되어 있음.
-  updateUser = async (userInfo: UpdateUserParams): Promise<void> => {
+  updateUser = async (userInfo: UserUpdateType): Promise<void> => {
     try {
       await axiosInstance.put("/members/login-user", userInfo);
       // console.log(response);
@@ -111,7 +111,7 @@ class AuthService {
   };
 
   // 이용약관 조회
-  fetchTerms = async (): Promise<TermsOfServiceType[] | null> => {
+  fetchTerms = async (): Promise<TermsOfServiceFetchType[] | null> => {
     try {
       const { data } = await axiosInstance.get("/terms-of-services");
       return data;

--- a/src/services/server/bookService.ts
+++ b/src/services/server/bookService.ts
@@ -1,18 +1,18 @@
 import { BookType, BookQuizzesType } from "../../types/BookType.ts";
 import { BookDetailType } from "../../types/BookDetailType.ts";
-import { BookCategory } from "../../types/GNBCategoryType.ts";
+import { BookCategoryType } from "../../types/GNBCategoryType.ts";
 import { axiosInstance } from "@/config/axiosConfig.ts";
 import { handleAxiosError } from "@/utils/errorHandler.ts";
 import {
-  FetchBooksParams,
-  FetchQuizzesParams,
-  SearchBooksParams,
+  BooksFetchType,
+  QuizzesFetchType,
+  BooksSearchType,
 } from "@/types/ParamsType.ts";
 
 // 책 목록, 책 상세정보 가져오기
 class BookService {
   fetchBooks = async (
-    params: FetchBooksParams = {},
+    params: BooksFetchType = {},
   ): Promise<{ data: BookType[]; endPageNumber: number } | void> => {
     const {
       title,
@@ -44,9 +44,7 @@ class BookService {
     }
   };
   // 책 통합검색
-  fetchSearchBooks = async (
-    params?: SearchBooksParams,
-  ): Promise<BookType[]> => {
+  fetchSearchBooks = async (params?: BooksSearchType): Promise<BookType[]> => {
     const { keyword, lastId = null, size = 20 } = params || {};
 
     try {
@@ -72,7 +70,7 @@ class BookService {
     }
   };
 
-  fetchBookCategories = async (): Promise<BookCategory[] | void> => {
+  fetchBookCategories = async (): Promise<BookCategoryType[] | void> => {
     try {
       const { data } = await axiosInstance.get("/book-categories");
       return data.details[0].details;
@@ -82,7 +80,7 @@ class BookService {
   };
 
   fetchBookQuizzes = async (
-    params: FetchQuizzesParams,
+    params: QuizzesFetchType,
   ): Promise<BookQuizzesType> => {
     try {
       const { page, size, sort, direction, bookId } = params;

--- a/src/services/server/quizService.ts
+++ b/src/services/server/quizService.ts
@@ -1,16 +1,19 @@
-import { QuizExplanationType, QuizRequestType } from "@/types/QuizType";
-import { QuizType, SolvingQuizType } from "@/types/QuizType";
-import { MyQuizType } from "@/types/QuizType";
+import {
+  QuizExplanationType as QuizExplanationFetchType,
+  QuizCreateType,
+} from "@/types/QuizType";
+import { QuizType, SolvingQuizFetchType } from "@/types/QuizType";
+import { MyQuizFetchType } from "@/types/QuizType";
 import { axiosInstance } from "@/config/axiosConfig";
-import { QuestionCheckedResult } from "@/types/QuizType";
+import { QuestionCheckedResultType } from "@/types/QuizType";
 import { handleAxiosError } from "@/utils/errorHandler";
-import { FetchQuizzesParams } from "@/types/ParamsType";
-import { SolvingQuizGradeResult } from "@/types/QuizType";
-import { SolvingQuizStudyGroupGradeResult } from "@/types/QuizType";
-import { FetchMyQuizzesParams } from "@/types/ParamsType";
+import { QuizzesFetchType } from "@/types/ParamsType";
+import { SolvingQuizGradeResultType as SolvingQuizGradeResultFetchType } from "@/types/QuizType";
+import { SolvingQuizStudyGroupGradeResultType as SolvingQuizStudyGroupGradeResultFetchType } from "@/types/QuizType";
+import { MyQuizzesFetchType } from "@/types/ParamsType";
 class QuizService {
   fetchQuizzes = async (
-    params: FetchQuizzesParams,
+    params: QuizzesFetchType,
   ): Promise<{ data: QuizType[]; endPageNumber: number } | null> => {
     try {
       const { page, size, bookId, sort, direction } = params;
@@ -27,9 +30,7 @@ class QuizService {
     }
   };
 
-  createQuiz = async (
-    quiz: QuizRequestType,
-  ): Promise<{ id: number } | null> => {
+  createQuiz = async (quiz: QuizCreateType): Promise<{ id: number } | null> => {
     try {
       const { data } = await axiosInstance.post("/book-quizzes", quiz);
       // console.log("data result: %o", data);
@@ -45,7 +46,7 @@ class QuizService {
     quiz,
   }: {
     editQuizId: string;
-    quiz: QuizRequestType;
+    quiz: QuizCreateType;
   }) => {
     try {
       await axiosInstance.put(`book-quizzes/${editQuizId}`, quiz);
@@ -55,8 +56,8 @@ class QuizService {
   };
 
   fetchMyMadeQuizzes = async (
-    params: FetchMyQuizzesParams,
-  ): Promise<MyQuizType | null> => {
+    params: MyQuizzesFetchType,
+  ): Promise<MyQuizFetchType | null> => {
     try {
       const { page, size, sort, direction } = params;
       const { data } = await axiosInstance.get(
@@ -70,8 +71,8 @@ class QuizService {
   };
 
   fetchMySolvedQuizzes = async (
-    params: FetchMyQuizzesParams,
-  ): Promise<MyQuizType | null> => {
+    params: MyQuizzesFetchType,
+  ): Promise<MyQuizFetchType | null> => {
     try {
       const { page, size, sort, direction } = params;
       const { data } = await axiosInstance.get(
@@ -84,7 +85,7 @@ class QuizService {
     }
   };
 
-  fetchQuiz = async (quizId: string): Promise<SolvingQuizType | null> => {
+  fetchQuiz = async (quizId: string): Promise<SolvingQuizFetchType | null> => {
     try {
       const { data } = await axiosInstance.get(
         `/book-quizzes/${quizId}/questions`,
@@ -98,7 +99,7 @@ class QuizService {
 
   fetchQuizExplanation = async (
     id: string,
-  ): Promise<QuizExplanationType | null> => {
+  ): Promise<QuizExplanationFetchType | null> => {
     try {
       const { data } = await axiosInstance.get(
         `/book-quizzes/${id}/explanation`,
@@ -112,7 +113,6 @@ class QuizService {
 
   // 북 퀴즈 풀기 시작 요청 함수. 백엔드 쪽에서 정답을 적을 omr카드 만드는 개념이라고 함..
   startSolvingQuiz = async (quizId: string): Promise<{ id: number } | null> => {
-    console.log("퀴즈 아이디", quizId);
     try {
       const { data } = await axiosInstance.post("/solving-quiz/start", {
         quizId: quizId,
@@ -128,7 +128,7 @@ class QuizService {
     solvingQuizId: string,
     questionId: number,
     answers: string[],
-  ): Promise<QuestionCheckedResult> => {
+  ): Promise<QuestionCheckedResultType> => {
     try {
       const { data } = await axiosInstance.post(
         `/solving-quiz/${solvingQuizId.toString()}/sheets`,
@@ -145,7 +145,7 @@ class QuizService {
 
   fetchGradeResult = async (
     solvingQuizId: string,
-  ): Promise<SolvingQuizGradeResult> => {
+  ): Promise<SolvingQuizGradeResultFetchType> => {
     try {
       const { data } = await axiosInstance.get(
         `/solving-quiz/${solvingQuizId}/grade-result`,
@@ -159,7 +159,7 @@ class QuizService {
   fetchStudyGradeResult = async (
     studyGroupId: string,
     quizId: string,
-  ): Promise<SolvingQuizStudyGroupGradeResult> => {
+  ): Promise<SolvingQuizStudyGroupGradeResultFetchType> => {
     try {
       const { data } = await axiosInstance.get(
         `/solving-quiz/study-groups-grade-result?studyGroupId=${studyGroupId}&quizId=${quizId}`,
@@ -206,7 +206,7 @@ class QuizService {
   };
 
   // 퀴즈 수정 시 사용되는 퀴즈 상세조회 (정답, 정답 설명을 포함한 조회)
-  fetchQuizzesDetail = async (quizId: string): Promise<QuizRequestType> => {
+  fetchQuizzesDetail = async (quizId: string): Promise<QuizCreateType> => {
     try {
       const response = await axiosInstance.get(`/book-quizzes/${quizId}`);
       return response.data;

--- a/src/services/server/reviewService.ts
+++ b/src/services/server/reviewService.ts
@@ -1,8 +1,8 @@
 import { axiosInstance } from "@/config/axiosConfig";
-import { FetchReviewsParams } from "@/types/ParamsType";
+import { ReviewsFetchType } from "@/types/ParamsType";
 import {
-  MyReviewType,
-  ReviewPostType,
+  MyReviewType as MyReviewFetchType,
+  ReviewCreateType,
   ReviewsTotalScoreType,
   ReviewType,
 } from "@/types/ReviewType";
@@ -11,7 +11,7 @@ import { handleAxiosError } from "@/utils/errorHandler";
 class ReviewService {
   // 퀴즈 요약 목록 조회
   fetchReviews = async (
-    params: FetchReviewsParams,
+    params: ReviewsFetchType,
   ): Promise<{ endPageNumber: number; data: ReviewType[] } | null> => {
     const { page = 1, size = 10, quizId, sort, direction } = params;
     try {
@@ -49,7 +49,7 @@ class ReviewService {
   };
 
   // 내가 작성한 퀴즈 리뷰 조회
-  fetchMyReview = async (quizId: number): Promise<MyReviewType | null> => {
+  fetchMyReview = async (quizId: number): Promise<MyReviewFetchType | null> => {
     try {
       const { data } = await axiosInstance.get("/quiz-reviews/my", {
         params: {
@@ -64,7 +64,7 @@ class ReviewService {
   };
 
   createQuizReview = async (
-    review: ReviewPostType,
+    review: ReviewCreateType,
   ): Promise<{ id: string } | null> => {
     try {
       const { data } = await axiosInstance.post("/quiz-reviews", review);
@@ -88,7 +88,7 @@ class ReviewService {
     review,
   }: {
     id: number;
-    review: ReviewPostType;
+    review: ReviewCreateType;
   }): Promise<void> => {
     try {
       await axiosInstance.put(`/quiz-reviews/${id}`, review);

--- a/src/services/server/studyGroupService.ts
+++ b/src/services/server/studyGroupService.ts
@@ -1,12 +1,12 @@
 import { axiosInstance } from "@/config/axiosConfig";
-import { FetchStudyGroupsParams } from "@/types/ParamsType";
+import { StudyGroupsFetchType } from "@/types/ParamsType";
 import {
-  StudyGroupPostType,
-  StudyGroupDetailType,
+  StudyGroupPostType as StudyGroupCreateType,
+  StudyGroupDetailType as StudyGroupDetailFetchType,
   StudyGroupMySolvedQuizType,
   StudyGroupMyUnSolvedQuizType,
   StudyGroupType,
-  QuizStudyGroupGradeResult,
+  QuizStudyGroupGradeResultType,
 } from "@/types/StudyGroupType";
 import { handleAxiosError } from "@/utils/errorHandler";
 
@@ -14,7 +14,7 @@ class StudyGroupService {
   // 스터디 그룹 상세 조회
   fetchStudyGroup = async (
     id: number,
-  ): Promise<StudyGroupDetailType | null> => {
+  ): Promise<StudyGroupDetailFetchType | null> => {
     try {
       const { data } = await axiosInstance.get(`/study-groups/${id}`);
       return data;
@@ -27,7 +27,7 @@ class StudyGroupService {
 
   // 내가 속한 스터디 그룹 조회
   fetchStudyGroups = async (
-    params: FetchStudyGroupsParams,
+    params: StudyGroupsFetchType,
   ): Promise<{ data: StudyGroupType[]; endPageNumber: number } | null> => {
     const { page, size, sort, direction } = params;
     try {
@@ -48,7 +48,7 @@ class StudyGroupService {
 
   // 스터디 그룹 생성
   createStudyGroup = async (
-    studyGroup: StudyGroupPostType,
+    studyGroup: StudyGroupCreateType,
   ): Promise<{ id: number } | null> => {
     try {
       const { data } = await axiosInstance.post("/study-groups", studyGroup);
@@ -75,7 +75,7 @@ class StudyGroupService {
   // 스터디 그룹 퀴즈 중 안 푼 문제 조회 (풀어야 할 퀴즈)
   fetchStudyGroupMyUnsolvedQuizzes = async (
     studyGroupId: number,
-    params: FetchStudyGroupsParams,
+    params: StudyGroupsFetchType,
   ): Promise<{
     endPageNumber: number;
     data: StudyGroupMyUnSolvedQuizType[];
@@ -105,7 +105,7 @@ class StudyGroupService {
   // 스터디 그룹 퀴즈 중 내가 푼 문제 조회 (제출 한 퀴즈)
   fetchStudyGroupMySolvedQuizzes = async (
     studyGroupId: number,
-    params: FetchStudyGroupsParams,
+    params: StudyGroupsFetchType,
   ): Promise<{
     endPageNumber: number;
     data: StudyGroupMySolvedQuizType[];
@@ -146,7 +146,7 @@ class StudyGroupService {
     studyGroup,
   }: {
     id: number;
-    studyGroup: StudyGroupPostType;
+    studyGroup: StudyGroupCreateType;
   }): Promise<void> => {
     try {
       await axiosInstance.put(`/study-groups/${id}`, studyGroup);
@@ -197,7 +197,7 @@ class StudyGroupService {
   }: {
     studyGroupId: number;
     quizId: number;
-  }): Promise<QuizStudyGroupGradeResult | null> => {
+  }): Promise<QuizStudyGroupGradeResultType | null> => {
     try {
       const response = await axiosInstance.get(
         "/solving-quiz/study-groups-grade-result",
@@ -219,7 +219,7 @@ class StudyGroupService {
   // 초대 코드를 통한 스터디 그룹 상세 조회
   fetchStudyGroupDetailByInviteCode = async (
     inviteCode: string,
-  ): Promise<StudyGroupDetailType | null> => {
+  ): Promise<StudyGroupDetailFetchType | null> => {
     try {
       const { data } = await axiosInstance.get(
         `/study-groups/invite-code/${inviteCode}`,

--- a/src/store/quizAtom.ts
+++ b/src/store/quizAtom.ts
@@ -1,5 +1,5 @@
 import { useIsQuizStepEnabled } from "@/hooks/useIsQuizStepEnabled";
-import { QuizCreationType } from "@/types/QuizType";
+import { QuizFormType } from "@/types/QuizType";
 import { atom } from "jotai";
 import { atomFamily } from "jotai/utils";
 
@@ -7,7 +7,7 @@ import { atomFamily } from "jotai/utils";
   /* 초기값 정의 */
 }
 
-const initialQuizCreationInfo: QuizCreationType = {
+const initialQuizCreationInfo: QuizFormType = {
   title: null,
   description: null,
   book: null,
@@ -23,9 +23,7 @@ const initialErrorModalTitle = "";
 {
   /* Atom 정의 */
 }
-export const quizCreationInfoAtom = atom<QuizCreationType>(
-  initialQuizCreationInfo,
-);
+export const quizCreationInfoAtom = atom<QuizFormType>(initialQuizCreationInfo);
 
 // 퀴즈 다음 버튼 활성화 여부 Atom
 export const isQuizNextButtonEnabledAtom = atom<boolean>((get) => {

--- a/src/styles/abstracts/_mixins.scss
+++ b/src/styles/abstracts/_mixins.scss
@@ -191,10 +191,13 @@
   height: 100%;
 }
 
-@mixin text-ellipsis {
-  white-space: nowrap;
+@mixin text-ellipsis($lines: 1) {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: $lines;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: normal;
 }
 
 @mixin questionExplanationImage {

--- a/src/types/BookDetailType.ts
+++ b/src/types/BookDetailType.ts
@@ -7,12 +7,12 @@ export interface BookDetailType {
   price: number;
   description: string;
   imageUrl: string;
-  categories: BookCategories[];
+  categories: BookCategoriesType[];
   authors: string[];
 }
 
-export interface BookCategories {
+export interface BookCategoriesType {
   id: string;
   name: string;
-  parent: BookCategories | null;
+  parent: BookCategoriesType | null;
 }

--- a/src/types/BookType.ts
+++ b/src/types/BookType.ts
@@ -5,12 +5,12 @@ export interface BookType {
   publisher: string;
   publishedAt: string;
   imageUrl: string;
-  categories: BookCategories[];
+  categories: BookCategoriesType[];
   authors: string[];
   quizCount?: number;
 }
 
-interface BookCategories {
+interface BookCategoriesType {
   id: string;
   name: string;
 }

--- a/src/types/CheckBoxTypes.ts
+++ b/src/types/CheckBoxTypes.ts
@@ -1,15 +1,15 @@
 import { ReactElement } from "react";
 // TODO: multipleChoiceQuizForm과 겹치는 부분 리팩토링 필요
 
-export interface CheckBoxOption {
+export interface CheckBoxOptionType {
   id: number;
   value: string;
   label: string;
   answerIndex?: number;
 }
 
-export interface CheckBoxProps {
-  option: CheckBoxOption;
+export interface CheckBoxType {
+  option: CheckBoxOptionType;
   selectedValue: string;
   onChange: (value: string) => void;
   isDisabled: boolean;

--- a/src/types/GNBCategoryType.ts
+++ b/src/types/GNBCategoryType.ts
@@ -1,5 +1,5 @@
-export interface BookCategory {
+export interface BookCategoryType {
   id: number;
   name: string;
-  details?: BookCategory[];
+  details?: BookCategoryType[];
 }

--- a/src/types/PaginationType.ts
+++ b/src/types/PaginationType.ts
@@ -1,12 +1,12 @@
 export type PagePositionType = "START" | "END" | "BETWEEN";
-export type ParentPage =
+export type ParentPageType =
   | "books"
   | "quiz"
   | "book"
   | "my/made-quiz"
   | "my/solved-quiz";
 export interface PaginationType {
-  parentPage?: ParentPage; // 페이지 타입: ex) 책 목록, 마이페이지
+  parentPage?: ParentPageType; // 페이지 타입: ex) 책 목록, 마이페이지
   currentPage: number;
   pagePosition: PagePositionType;
   totalPagesLength: number | undefined;

--- a/src/types/ParamsType.ts
+++ b/src/types/ParamsType.ts
@@ -5,7 +5,7 @@ import {
 } from "./FilterType";
 
 // BOOK
-export interface FetchBooksParams {
+export interface BooksFetchType {
   title?: string;
   authorName?: string;
   description?: string;
@@ -15,16 +15,16 @@ export interface FetchBooksParams {
   sort?: BooksFilterType["sort"];
   direction?: BooksFilterType["direction"];
 }
-export type FetchBooksKeyType = keyof FetchBooksParams;
+export type BooksFetchKeyType = keyof BooksFetchType;
 
-export interface SearchBooksParams {
+export interface BooksSearchType {
   keyword?: string;
   lastId?: number;
   size?: number;
 }
 
 // REVIEW
-export interface FetchReviewsParams {
+export interface ReviewsFetchType {
   quizId: number;
   page?: number;
   size?: number;
@@ -32,14 +32,14 @@ export interface FetchReviewsParams {
   direction?: ReviewsFilterType["direction"];
 }
 
-export interface NavigateReviewParams {
+export interface ReviewNavigateType {
   solvingQuizId: string;
   quizTitle: string;
 }
 
 // QUIZ
 // TODO: 필드 타입 수정 필요
-export interface FetchQuizzesParams {
+export interface QuizzesFetchType {
   page: string;
   size: string;
   bookId: string;
@@ -48,7 +48,7 @@ export interface FetchQuizzesParams {
 }
 
 // 내가 만든 퀴즈, 내가 푼 퀴즈
-export interface FetchMyQuizzesParams {
+export interface MyQuizzesFetchType {
   page: string;
   size: string;
   sort: string;
@@ -56,7 +56,7 @@ export interface FetchMyQuizzesParams {
 }
 
 // STUDY GROUP
-export interface FetchStudyGroupsParams {
+export interface StudyGroupsFetchType {
   page?: number;
   size?: number;
   sort?: StudyGroupsFilterType["sort"];
@@ -65,7 +65,7 @@ export interface FetchStudyGroupsParams {
 
 // Auth
 
-export interface UpdateUserParams {
+export interface UserUpdateType {
   nickname?: string;
   email?: string;
   profileImage?: string | null;
@@ -73,14 +73,14 @@ export interface UpdateUserParams {
 
 // ROUTES
 
-export interface QuizResultRouteParams {
+export interface QuizResultRouteType {
   quizId: number;
   solvingQuizId: number;
   quizTitle: string;
   studyGroupId?: string;
 }
 
-export interface QuizReviewRouteParams {
+export interface QuizReviewRouteType {
   quizId: number;
   solvingQuizId: number;
   quizTitle: string;

--- a/src/types/QuizType.ts
+++ b/src/types/QuizType.ts
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
 import { BookType } from "./BookType";
 import { StudyGroupType } from "./StudyGroupType";
-import { SolvingQuizStudyGroupUser } from "./UserType";
+import { SolvingQuizStudyGroupUserType } from "./UserType";
 
 interface CreatorType {
   id: number;
@@ -36,7 +36,7 @@ export interface QuizExplanationType {
 }
 
 // 퀴즈 풀기 시 사용되는 타입
-export interface SolvingQuizType {
+export interface SolvingQuizFetchType {
   id: number;
   title: string;
   studyGroupId?: number;
@@ -51,7 +51,7 @@ export interface SolvingQuizQuestionType {
   type: AnswerType;
 }
 
-export interface MyQuizType {
+export interface MyQuizFetchType {
   endPageNumber: number;
   data: MyQuizDataType[];
 }
@@ -63,11 +63,6 @@ export interface MyQuizDataType {
   description: string;
   updatedAt: string;
   studyGroup?: MyQuizStudyGroupType;
-}
-
-export interface MySolvedQuizType {
-  endPageNumber: number;
-  data: MySolvedQuizDataType[];
 }
 
 export interface MySolvedQuizDataType {
@@ -91,14 +86,18 @@ interface SolvedQuizType {
   creator: CreatorType;
 }
 
-export type ViewScope = "EVERYONE" | "STUDY_GROUP" | "CREATOR";
-export type EditScope = "EVERYONE" | "STUDY_GROUP" | "CREATOR";
-export const scopeTranslations: Record<string, ViewScope | EditScope> = {
-  모두: "EVERYONE",
-  스터디원만: "STUDY_GROUP",
-  나만: "CREATOR",
-};
-export const scopeReverseTranslations: Record<ViewScope | EditScope, string> = {
+export type ViewScopeType = "EVERYONE" | "STUDY_GROUP" | "CREATOR";
+export type EditScopeType = "EVERYONE" | "STUDY_GROUP" | "CREATOR";
+export const scopeTranslations: Record<string, ViewScopeType | EditScopeType> =
+  {
+    모두: "EVERYONE",
+    스터디원만: "STUDY_GROUP",
+    나만: "CREATOR",
+  };
+export const scopeReverseTranslations: Record<
+  ViewScopeType | EditScopeType,
+  string
+> = {
   EVERYONE: "모두",
   STUDY_GROUP: "스터디원만",
   CREATOR: "나만",
@@ -110,49 +109,53 @@ export type AnswerType =
   | "MULTIPLE_CHOICE_SINGLE_ANSWER"
   | "MULTIPLE_CHOICE_MULTIPLE_ANSWER"
   | "SHORT";
-
-export interface QuizCreationType {
+export interface QuizFormType {
+  // 퀴즈 폼 작성 중 사용되는 타입 : FormType
   title: string | null;
   description: string | null;
   book: BookType | null;
-  viewScope: ViewScope | null;
-  editScope: EditScope | null;
+  viewScope: ViewScopeType | null;
+  editScope: EditScopeType | null;
   studyGroup: StudyGroupType | null | undefined; // undefined -> 스터디그룹 선택 안함
-  questions: QuizQuestionType[] | null;
+  questions: QuizQuestionFormType[] | null;
 }
 
-export interface SelectOptionType {
+export interface SelectOptionFormType {
   id: number;
   option: string;
   value: string;
   answerIndex: number;
 }
 
-export interface QuizQuestionType {
+export interface QuizQuestionFormType {
+  // 퀴즈 질문 폼 유저 입력의 객체 구조 정의
   id: number;
   content: string;
-  selectOptions: SelectOptionType[];
+  selectOptions: SelectOptionFormType[];
   answerExplanationContent: string;
   answerExplanationImages: JSX.Element[];
   answerType: AnswerType;
   answers: string[];
 }
 
-export interface QuizRequestType {
-  // TODO: 이름 아래와 통일 필요
+export interface QuizCreateType {
+  // TODO: 생성요청, fetchQuizzesDetail(퀴즈 수정 시 사용되는 퀴즈 상세조회 (정답, 정답 설명을 포함한 조회))에서도 사용됨.
+  // 임시저장이 fetchQuizzesDetail에서는 필요하지 않으므로 임시저장 기능 구현 시 temporary를 제외한 타입을 base로 만들면 좋을듯
+
+  // 퀴즈 생성 요청 타입
   id?: string;
   title: string;
   description: string;
   bookId: number;
   timeLimitSecond?: number;
-  viewScope: ViewScope;
-  editScope: EditScope;
+  viewScope: ViewScopeType;
+  editScope: EditScopeType;
   studyGroupId?: number | null;
-  questions: QuizQuestionRequestApiType[];
+  questions: QuizQuestionCreateType[];
   // temporary: boolean; // 임시 저장 여부
 }
 
-export type QuizQuestionRequestApiType = {
+export type QuizQuestionCreateType = {
   id?: number; // 수정하기 api 요청 시 id가 없으면 create, 있으면 modify
   content: string;
   selectOptions: string[];
@@ -163,12 +166,13 @@ export type QuizQuestionRequestApiType = {
 };
 
 export interface QuestionFormType {
+  // 퀴즈 질문 폼의 객체 구조 정의
   id: number;
   answerType: AnswerType;
   component: ReactNode;
 }
 
-export interface QuestionCheckedResult {
+export interface QuestionCheckedResultType {
   solvingQuizId: number;
   playerId: number;
   quizId: number;
@@ -191,7 +195,7 @@ export interface QuizSettingType {
   icon: string; // path
 }
 
-export interface SolvingQuizGradeResult {
+export interface SolvingQuizGradeResultType {
   solvingQuizId: number;
   quizId: number;
   playerId: number;
@@ -199,16 +203,16 @@ export interface SolvingQuizGradeResult {
   correctCount: number;
 }
 
-export interface SolvingQuizStudyGroupGradeResult {
+export interface SolvingQuizStudyGroupGradeResultType {
   quizId: number;
   studyGroupId: number;
   totalQuestionCount: number;
-  solvedMember: SolvedMember[];
-  unSolvedMember: SolvingQuizStudyGroupUser[];
+  solvedMember: SolvedMemberType[];
+  unSolvedMember: SolvingQuizStudyGroupUserType[];
 }
 
-export interface SolvedMember {
-  member: SolvingQuizStudyGroupUser;
+export interface SolvedMemberType {
+  member: SolvingQuizStudyGroupUserType;
   solvingQuizId: number;
   correctCount: number;
 }

--- a/src/types/ReviewType.ts
+++ b/src/types/ReviewType.ts
@@ -19,7 +19,7 @@ export interface MyReviewType
   > {}
 
 // 퀴즈 리뷰 생성 타입
-export interface ReviewPostType {
+export interface ReviewCreateType {
   starRating: number;
   difficultyLevel: number;
   comment: string;

--- a/src/types/StepType.ts
+++ b/src/types/StepType.ts
@@ -1,7 +1,7 @@
 import { Dispatch } from "react";
 import { SetStateAction } from "jotai";
 
-export interface FormComponentProps {
+export interface FormComponentType {
   setCurrentStep: Dispatch<SetStateAction<number>>;
 }
 
@@ -10,7 +10,7 @@ export interface Step {
   icon?: string;
   title: string;
   description?: string;
-  formComponent?: (props?: FormComponentProps) => JSX.Element;
+  formComponent?: (props?: FormComponentType) => JSX.Element;
   subSteps?: Step[];
   isDone?: boolean;
   sectionId?: string;

--- a/src/types/StudyGroupType.ts
+++ b/src/types/StudyGroupType.ts
@@ -75,7 +75,7 @@ export interface SolvedMemberType {
 }
 
 // 스터디 그룹 내 랭킹 조회
-export interface QuizStudyGroupGradeResult {
+export interface QuizStudyGroupGradeResultType {
   quizId: number;
   studyGroupId: number;
   totalQuestionCount: number;

--- a/src/types/UserType.ts
+++ b/src/types/UserType.ts
@@ -26,7 +26,7 @@ export type UserProfileType = UserBaseType & {
   profileImage: string;
 };
 
-export type SolvingQuizStudyGroupUser = Omit<UserBaseType, "email"> & {
+export type SolvingQuizStudyGroupUserType = Omit<UserBaseType, "email"> & {
   email?: string;
   profileImageUrl?: string;
 };

--- a/src/utils/extractCategoryList.ts
+++ b/src/utils/extractCategoryList.ts
@@ -1,10 +1,10 @@
-import { ListItem } from "@/components/composite/Breadcrumb/Breadcrumb";
-import { BookCategories } from "@/types/BookDetailType";
+import { ListItemType } from "@/components/composite/Breadcrumb/Breadcrumb";
+import { BookCategoriesType } from "@/types/BookDetailType";
 
 export const extractCategoryList = (
-  data: BookCategories,
-  list: ListItem[] = [],
-): ListItem[] => {
+  data: BookCategoriesType,
+  list: ListItemType[] = [],
+): ListItemType[] => {
   if (data.parent) {
     list.unshift({ id: Number(data.id), name: data.name });
     return extractCategoryList(data.parent, list);

--- a/src/utils/findCategoryInfo.ts
+++ b/src/utils/findCategoryInfo.ts
@@ -1,12 +1,12 @@
-import { BookCategory } from "@/types/GNBCategoryType";
+import { BookCategoryType } from "@/types/GNBCategoryType";
 
 // 가장 상위의 부모 카테고리 아이디를 찾음
 export const findTopParentCategoryInfo = (
-  categories: BookCategory[],
+  categories: BookCategoryType[],
   targetId: number,
 ): { id: number; name: string } | null => {
   const traverse = (
-    items: BookCategory[],
+    items: BookCategoryType[],
     parent: { id: number; name: string } | null,
   ): { id: number; name: string } | null => {
     for (const item of items) {
@@ -35,11 +35,11 @@ export const findTopParentCategoryInfo = (
 
 // 한 단계 상위의 부모 카테고리 아이디를 찾음
 export const findParentCategoryInfo = (
-  categories: BookCategory[],
+  categories: BookCategoryType[],
   targetId: number,
 ): { id: number; name: string } | null => {
   const traverse = (
-    items: BookCategory[],
+    items: BookCategoryType[],
   ): { id: number; name: string } | null => {
     for (const item of items) {
       // 현재 아이템의 자식에서 targetId를 찾으면 현재 아이템의 id와 name 반환
@@ -63,11 +63,11 @@ export const findParentCategoryInfo = (
 
 // 본인의 Id와 name 반환
 export const findCurrentCategoryInfo = (
-  categories: BookCategory[],
+  categories: BookCategoryType[],
   targetId: number,
 ): { id: number; name: string } | null => {
   const traverse = (
-    items: BookCategory[],
+    items: BookCategoryType[],
   ): { id: number; name: string } | null => {
     for (const item of items) {
       // targetId와 일치하는 항목을 찾으면 id와 name 반환


### PR DESCRIPTION
### Release 1.2.3 변경사항

#### 🛠 Fix (버그 수정)
- **퀴즈 관련**  
  - LNB의 left-arrow 클릭 시 책 목록으로 이동하도록 수정 (DK-567)

#### ✨ Feat (기능 추가)
- **페이지네이션 성능 최적화**  
  - `useMemo`를 사용하여 페이지네이션 렌더링 최적화 (DK-567)

#### 🎨 Style (디자인 및 UI 개선)
- **퀴즈 목록 및 마이페이지 스타일 개선**  
  - 퀴즈 목록 아이템의 퀴즈 제목을 한 줄로 제한 (DK-567)  
  - 마이페이지 퀴즈 아이템의 책 사진 `max-height` 설정 (DK-567)  
  - 마이페이지 퀴즈 아이템 `width` 지정 및 text overflow 처리 믹스인에 줄 수 지정 기능 추가 (DK-567)  
- **문제 작성 가이드 스타일 수정**  
  - 변경된 디자인에 맞추어 문제 작성 가이드 스타일 수정 (DK-567)

#### 📦 Chore & Refactor (리팩토링 및 기타)
- **컴포넌트 및 타입 정리**  
  - 컴포넌트 props 이름을 `Props`로 통일 (DK-565)  
  - 타입 컨벤션에 맞게 이름 수정 (DK-565) [관련문서](https://www.notion.so/6e65ac4c71e54376a90df38352e693f4)