### PR TITLE
Release 1.3.1 Fix(DK-604): 스터디 그룹 정보 수정 폼 입력 변경에 따른 버튼 노출 로직 수정

### DIFF
--- a/src/pages/MyPage/composite/StudyGroupSetting/StudyGroupSetting.tsx
+++ b/src/pages/MyPage/composite/StudyGroupSetting/StudyGroupSetting.tsx
@@ -108,15 +108,12 @@ export default function StudyGroupSetting() {
     useState<ProfileImageState>(initialProfileState);
 
   useEffect(() => {
-    if (
+    const isChanged =
       name !== studyGroupDetail?.name ||
-      introduction !== studyGroupDetail?.introduction
-    ) {
-      setIsInputChanged(true);
-    } else {
-      setIsInputChanged(false);
-    }
-    if (profileImage.url !== studyGroupDetail?.profileImageUrl) {
+      introduction !== studyGroupDetail?.introduction ||
+      profileImage.url !== studyGroupDetail?.profileImageUrl;
+
+    if (isChanged) {
       setIsInputChanged(true);
     } else {
       setIsInputChanged(false);


### PR DESCRIPTION
- 스터디 그룹 정보 수정 폼 입력 변경에 따른 버튼 노출이 의도대로 동작하지 않던 문제가 있었습니다.
- 인풋창 입력 값 비교와 이미지 변경 비교 로직이 겹쳐서(값이 덮어씌워지는 문제) 제대로 동작하지 않는, 로직이 잘못된 부분을 수정하였습니다. 